### PR TITLE
Change the default shortcut for the "show all" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A powerful VS Code extension that adds customizable command buttons to your stat
 
 ### Quick Command Palette
 
-- **Unified access**: View all commands in one searchable interface (`Ctrl/Cmd+Shift+Q`)
+- **Unified access**: View all commands in one searchable interface (`Ctrl/Cmd+Shift+;`)
 - **Shortcut navigation**: Type single characters to instantly execute commands with shortcuts
 - **Smart filtering**: Search by command name or description to find what you need
 
@@ -53,7 +53,7 @@ A powerful VS Code extension that adds customizable command buttons to your stat
 3. **Access via multiple methods**:
    - **Status bar**: Click buttons for direct execution or group menus
    - **Tree view**: Open "Quick Commands" panel for comprehensive management
-   - **Command palette**: Use `Ctrl/Cmd+Shift+Q` to open unified command interface
+   - **Command palette**: Use `Ctrl/Cmd+Shift+;` to open unified command interface
 
 ## Configuration
 
@@ -166,7 +166,7 @@ Combine terminal commands (builds, tests) with VS Code API commands (formatting,
 
 | Command                               | Keybinding                            | Description                                                             |
 | ------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------- |
-| `quickCommandButtons.showAllCommands` | `Ctrl+Shift+Q` (`Cmd+Shift+Q` on Mac) | Show all configured commands in a searchable list with shortcut support |
+| `quickCommandButtons.showAllCommands` | `Ctrl+Shift+;` (`Cmd+Shift+;` on Mac) | Show all configured commands in a searchable list with shortcut support |
 | `quickCommandButtons.refreshTree`     |                                       | Refresh the tree view panel                                             |
 | `quickCommandButtons.executeFromTree` |                                       | Execute command from tree view                                          |
 

--- a/src/package.json
+++ b/src/package.json
@@ -67,8 +67,8 @@
     "keybindings": [
       {
         "command": "quickCommandButtons.showAllCommands",
-        "key": "ctrl+shift+q",
-        "mac": "cmd+shift+q"
+        "key": "ctrl+shift+;",
+        "mac": "cmd+shift+;"
       }
     ],
     "configuration": {


### PR DESCRIPTION
The "ctrl/cmd + shift + q" shortcut, which closes all apps by default on Mac, is rarely used across various environments, including Windows, Mac, and VScode. Therefore, we've changed it to a shortcut that doesn't conflict with the default.

#6