### PR TITLE
Fix CI test workflow just command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: extractions/setup-just@v3
 
       - name: Install dependencies
-        run: just deps extension
+        run: just deps-extension
 
       - name: Run tests with coverage
         run: just test coverage


### PR DESCRIPTION
Workflow was calling non-existent 'deps extension' while justfile defines 'deps-extension' recipe"