### PR TITLE
Fix error when PR author tries to add themselves as reviewer

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -12,6 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add owner as reviewer
+        if: github.event.pull_request.user.login != github.repository_owner
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --add-reviewer ${{ github.repository_owner }} \


### PR DESCRIPTION
HTTP 422 error occurred when PR author and repository owner were the same person Added condition to only add reviewer when PR author is not the repository owner