### PR TITLE
feat: add timeout and error handling for webview-extension communication

### DIFF
--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -8,6 +8,7 @@
     "@indic-transliteration/sanscript": "1.3.3",
     "convert-layout": "0.11.1",
     "tiny-pinyin": "1.3.2",
-    "wanakana": "5.3.1"
+    "wanakana": "5.3.1",
+    "zod": "4.1.12"
   }
 }

--- a/src/extension/pnpm-lock.yaml
+++ b/src/extension/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       wanakana:
         specifier: 5.3.1
         version: 5.3.1
+      zod:
+        specifier: 4.1.12
+        version: 4.1.12
 
 packages:
   "@indic-transliteration/common_maps@1.0.5":
@@ -58,6 +61,12 @@ packages:
       }
     engines: { node: ">=12" }
 
+  zod@4.1.12:
+    resolution:
+      {
+        integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==,
+      }
+
 snapshots:
   "@indic-transliteration/common_maps@1.0.5": {}
 
@@ -73,3 +82,5 @@ snapshots:
   toml@2.3.6: {}
 
   wanakana@5.3.1: {}
+
+  zod@4.1.12: {}

--- a/src/shared/constants.spec.ts
+++ b/src/shared/constants.spec.ts
@@ -1,0 +1,36 @@
+import { MESSAGE_TYPE, MESSAGES } from "./constants";
+
+describe("Webview Communication Error Handling", () => {
+  describe("Message constants", () => {
+    it("should have ERROR message type", () => {
+      expect(MESSAGE_TYPE.ERROR).toBe("error");
+    });
+
+    it("should have communication timeout error message", () => {
+      const message = MESSAGES.ERROR.communicationTimeout;
+      expect(message).toContain("timed out");
+      expect(message).toBeTruthy();
+    });
+
+    it("should have extension error message template", () => {
+      const testError = "Test error";
+      const message = MESSAGES.ERROR.extensionError(testError);
+      expect(message).toContain(testError);
+      expect(message).toBeTruthy();
+    });
+  });
+
+  describe("Timeout handling", () => {
+    it("should reject promise when timeout occurs", async () => {
+      const COMMUNICATION_TIMEOUT = 100; // Short timeout for testing
+
+      const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(MESSAGES.ERROR.communicationTimeout));
+        }, COMMUNICATION_TIMEOUT);
+      });
+
+      await expect(timeoutPromise).rejects.toThrow(MESSAGES.ERROR.communicationTimeout);
+    });
+  });
+});

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -15,6 +15,7 @@ export const CONFIGURATION_TARGET = {
 export const MESSAGE_TYPE = {
   CONFIG_DATA: "configData",
   CONFIGURATION_TARGET_CHANGED: "configurationTargetChanged",
+  ERROR: "error",
   GET_CONFIG: "getConfig",
   SET_CONFIG: "setConfig",
   SET_CONFIGURATION_TARGET: "setConfigurationTarget",
@@ -22,11 +23,17 @@ export const MESSAGE_TYPE = {
 
 export const MESSAGES = {
   ERROR: {
+    communicationTimeout: "Communication with extension timed out. Please try again.",
     contextRequired: (hookName: string) =>
       `${hookName} must be used within a VscodeCommandProvider`,
     duplicateShortcuts: (shortcuts: string[]) =>
       `Duplicate shortcuts detected: ${shortcuts.join(", ")}. Please ensure each shortcut is unique.`,
+    extensionError: (error: string) => `Extension error: ${error}`,
+    invalidConfigurationTarget: (target: string) =>
+      `Invalid target for setConfigurationTarget: ${target}`,
+    invalidSetConfigData: "Invalid data for setConfig: data is not an array.",
     noCommands: "No commands found",
+    unknownError: "Unknown error occurred",
   },
   INFO: {
     commandsCount: (count: number) => `${count} commands`,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -18,17 +18,48 @@ export type RefreshButtonConfig = {
 
 export type WebviewMessageType = "getConfig" | "setConfig" | "setConfigurationTarget";
 
-export type ExtensionMessageType = "configData" | "configurationTargetChanged";
+export type ExtensionMessageType =
+  | "configData"
+  | "configurationTargetChanged"
+  | "error"
+  | "success";
 
 export type WebviewMessage = {
   data?: ButtonConfig[] | ButtonConfig | string;
+  requestId?: string;
   target?: string;
   type: WebviewMessageType;
 };
 
-export type ExtensionMessage = {
-  data?: ButtonConfig[] | string;
-  type: ExtensionMessageType;
+export type ConfigDataMessage = {
+  data: {
+    buttons: ButtonConfig[];
+    configurationTarget: string;
+  };
+  requestId?: string;
+  type: "configData";
 };
+
+export type SuccessMessage = {
+  requestId?: string;
+  type: "success";
+};
+
+export type ErrorMessage = {
+  error: string;
+  requestId?: string;
+  type: "error";
+};
+
+export type ConfigurationTargetChangedMessage = {
+  requestId?: string;
+  type: "configurationTargetChanged";
+};
+
+export type ExtensionMessage =
+  | ConfigDataMessage
+  | ConfigurationTargetChangedMessage
+  | ErrorMessage
+  | SuccessMessage;
 
 export type ConfigurationTarget = "global" | "workspace";

--- a/src/view/src/hooks/use-webview-communication.tsx
+++ b/src/view/src/hooks/use-webview-communication.tsx
@@ -1,0 +1,76 @@
+import { useRef, useCallback } from "react";
+
+import { MESSAGES } from "../../../shared/constants";
+import { vscodeApi } from "../core/vscode-api";
+import type { ButtonConfig } from "../types";
+
+const COMMUNICATION_TIMEOUT = 5000;
+
+type MessageData = ButtonConfig[] | { target: string };
+
+type PendingRequest = {
+  resolve: () => void;
+  timeout: NodeJS.Timeout;
+};
+
+export const useWebviewCommunication = () => {
+  const pendingRequestsRef = useRef<Map<string, PendingRequest>>(new Map());
+
+  const generateRequestId = useCallback((messageType: string): string => {
+    return `${messageType}_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }, []);
+
+  const sendMessage = useCallback(
+    (
+      messageType: "getConfig" | "setConfig" | "setConfigurationTarget",
+      messageData?: MessageData
+    ): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        const requestId = generateRequestId(messageType);
+
+        const timeout = setTimeout(() => {
+          pendingRequestsRef.current.delete(requestId);
+          const errorMsg = MESSAGES.ERROR.communicationTimeout;
+          console.error(errorMsg);
+          reject(new Error(errorMsg));
+        }, COMMUNICATION_TIMEOUT);
+
+        pendingRequestsRef.current.set(requestId, { resolve, timeout });
+
+        const isButtonConfigArray = Array.isArray(messageData);
+        const data = isButtonConfigArray ? messageData : undefined;
+        const target = !isButtonConfigArray && messageData ? messageData.target : undefined;
+
+        vscodeApi.postMessage({
+          data,
+          requestId,
+          target,
+          type: messageType,
+        });
+      });
+    },
+    [generateRequestId]
+  );
+
+  const resolveRequest = useCallback((requestId?: string) => {
+    if (!requestId) return;
+
+    const pending = pendingRequestsRef.current.get(requestId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      pending.resolve();
+      pendingRequestsRef.current.delete(requestId);
+    }
+  }, []);
+
+  const clearAllRequests = useCallback(() => {
+    pendingRequestsRef.current.forEach(({ timeout }) => clearTimeout(timeout));
+    pendingRequestsRef.current.clear();
+  }, []);
+
+  return {
+    clearAllRequests,
+    resolveRequest,
+    sendMessage,
+  };
+};


### PR DESCRIPTION
Added reliability mechanisms to message communication between Webview and Extension.

Key changes:
- Prevent infinite waiting with 5-second timeout
- Track request-response with requestId to prevent message loss
- Improve type safety with Discriminated Union types
- Encapsulate communication logic into Custom Hook (useWebviewCommunication) for better reusability

fix #82