### PR TITLE
refactor: separate web-view components into individual files

### DIFF
--- a/src/view/src/components/command-card.tsx
+++ b/src/view/src/components/command-card.tsx
@@ -1,0 +1,93 @@
+import { GripVertical } from "lucide-react";
+
+import { Badge, Button } from "~/core";
+
+import { DeleteConfirmationDialog } from "./delete-confirmation-dialog";
+import { useCommandForm } from "../context/command-form-context.tsx";
+import { useVscodeCommand } from "../context/vscode-command-context.tsx";
+import { useSortableItem } from "../hooks/use-sortable-item";
+import { type ButtonConfig } from "../types";
+
+type CommandCardProps = {
+  command: ButtonConfig;
+  id: string;
+  index: number;
+};
+
+export const CommandCard = ({ command, id, index }: CommandCardProps) => {
+  const { deleteCommand } = useVscodeCommand();
+  const { openEditForm } = useCommandForm();
+
+  const { attributes, listeners, setNodeRef, style } = useSortableItem(id);
+
+  return (
+    <div
+      className="flex items-center justify-between p-4 border border-border rounded-lg hover:border-border/80 transition-colors"
+      ref={setNodeRef}
+      style={style}
+    >
+      <div className="flex items-center space-x-3">
+        <div
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+          title="Drag to reorder"
+        >
+          <GripVertical size={16} />
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center space-x-3">
+            <span
+              className="font-medium"
+              style={{ color: command.color || "hsl(var(--foreground))" }}
+            >
+              {command.name}
+            </span>
+            {command.shortcut && (
+              <Badge className="font-mono" variant="secondary">
+                {command.shortcut}
+              </Badge>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground mt-1">
+            {command.group ? (
+              <span className="text-primary">Group with {command.group.length} commands</span>
+            ) : (
+              <span className="font-mono">{command.command || "No command"}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Button
+          className="p-2"
+          onClick={() => openEditForm(command, index)}
+          size="sm"
+          variant="ghost"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+            />
+          </svg>
+        </Button>
+
+        <DeleteConfirmationDialog commandName={command.name} onConfirm={() => deleteCommand(index)}>
+          <Button className="p-2 hover:text-destructive" size="sm" variant="ghost">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+              />
+            </svg>
+          </Button>
+        </DeleteConfirmationDialog>
+      </div>
+    </div>
+  );
+};

--- a/src/view/src/components/command-list.tsx
+++ b/src/view/src/components/command-list.tsx
@@ -1,13 +1,8 @@
-import { GripVertical } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "~/core";
 
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "~/core";
-
-import { DeleteConfirmationDialog } from "./delete-confirmation-dialog";
-import { useCommandForm } from "../context/command-form-context.tsx";
+import { CommandCard } from "./command-card";
 import { useVscodeCommand } from "../context/vscode-command-context.tsx";
-import { useSortableItem } from "../hooks/use-sortable-item";
 import { useSortableList } from "../hooks/use-sortable-list";
-import { type ButtonConfig } from "../types";
 
 export const CommandList = () => {
   const { commands, reorderCommands } = useVscodeCommand();
@@ -38,89 +33,5 @@ export const CommandList = () => {
         )}
       </CardContent>
     </Card>
-  );
-};
-
-type CommandCardProps = {
-  command: ButtonConfig;
-  id: string;
-  index: number;
-};
-
-const CommandCard = ({ command, id, index }: CommandCardProps) => {
-  const { deleteCommand } = useVscodeCommand();
-  const { openEditForm } = useCommandForm();
-
-  const { attributes, listeners, setNodeRef, style } = useSortableItem(id);
-
-  return (
-    <div
-      className="flex items-center justify-between p-4 border border-border rounded-lg hover:border-border/80 transition-colors"
-      ref={setNodeRef}
-      style={style}
-    >
-      <div className="flex items-center space-x-3">
-        <div
-          {...attributes}
-          {...listeners}
-          className="cursor-grab active:cursor-grabbing flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
-          title="Drag to reorder"
-        >
-          <GripVertical size={16} />
-        </div>
-        <div className="flex-1">
-          <div className="flex items-center space-x-3">
-            <span
-              className="font-medium"
-              style={{ color: command.color || "hsl(var(--foreground))" }}
-            >
-              {command.name}
-            </span>
-            {command.shortcut && (
-              <Badge className="font-mono" variant="secondary">
-                {command.shortcut}
-              </Badge>
-            )}
-          </div>
-          <div className="text-sm text-muted-foreground mt-1">
-            {command.group ? (
-              <span className="text-primary">Group with {command.group.length} commands</span>
-            ) : (
-              <span className="font-mono">{command.command || "No command"}</span>
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="flex items-center space-x-2">
-        <Button
-          className="p-2"
-          onClick={() => openEditForm(command, index)}
-          size="sm"
-          variant="ghost"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-            />
-          </svg>
-        </Button>
-
-        <DeleteConfirmationDialog commandName={command.name} onConfirm={() => deleteCommand(index)}>
-          <Button className="p-2 hover:text-destructive" size="sm" variant="ghost">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-              />
-            </svg>
-          </Button>
-        </DeleteConfirmationDialog>
-      </div>
-    </div>
   );
 };

--- a/src/view/src/components/group-command-editor.tsx
+++ b/src/view/src/components/group-command-editor.tsx
@@ -1,101 +1,14 @@
 import { useState, useCallback } from "react";
 
-import {
-  Button,
-  Checkbox,
-  Input,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogBody,
-  DialogFooter,
-  FormLabel,
-} from "~/core";
-
 import { type ButtonConfig } from "../types";
 import { GroupCommandList } from "./group-command-list";
+import { GroupEditDialog } from "./group-edit-dialog";
 
 type GroupCommandEditorProps = {
   commands: ButtonConfig[];
   depth?: number;
   onChange: (commands: ButtonConfig[]) => void;
   title?: string;
-};
-
-type GroupEditDialogProps = {
-  depth: number;
-  group: ButtonConfig;
-  isOpen: boolean;
-  onClose: () => void;
-  onSave: (group: ButtonConfig) => void;
-  title: string;
-};
-
-const GroupEditDialog = ({
-  depth,
-  group,
-  isOpen,
-  onClose,
-  onSave,
-  title,
-}: GroupEditDialogProps) => {
-  const [localGroup, setLocalGroup] = useState(group);
-
-  const handleSave = () => {
-    onSave(localGroup);
-    onClose();
-  };
-
-  const handleCancel = () => {
-    onClose();
-  };
-
-  return (
-    <Dialog onOpenChange={onClose} open={isOpen}>
-      <DialogContent className="max-w-4xl">
-        <DialogHeader>
-          <DialogTitle>Edit Group: {title}</DialogTitle>
-        </DialogHeader>
-        <DialogBody>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <FormLabel htmlFor="group-name">Group Name</FormLabel>
-              <Input
-                id="group-name"
-                onChange={(e) => setLocalGroup({ ...localGroup, name: e.target.value })}
-                placeholder="Group name"
-                value={localGroup.name}
-              />
-              <Checkbox
-                checked={localGroup.executeAll || false}
-                id="execute-all"
-                label="Execute all commands simultaneously"
-                onCheckedChange={(checked) =>
-                  setLocalGroup({ ...localGroup, executeAll: !!checked })
-                }
-              />
-            </div>
-
-            <GroupCommandEditor
-              commands={localGroup.group || []}
-              depth={depth + 1}
-              onChange={(commands) => setLocalGroup({ ...localGroup, group: commands })}
-              title={`${title} Commands`}
-            />
-          </div>
-        </DialogBody>
-        <DialogFooter>
-          <Button onClick={handleCancel} type="button" variant="outline">
-            Cancel
-          </Button>
-          <Button onClick={handleSave} type="button">
-            Save
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
 };
 
 export const GroupCommandEditor = ({

--- a/src/view/src/components/group-edit-dialog.tsx
+++ b/src/view/src/components/group-edit-dialog.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+
+import {
+  Button,
+  Checkbox,
+  Input,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+  FormLabel,
+} from "~/core";
+
+import { type ButtonConfig } from "../types";
+import { GroupCommandEditor } from "./group-command-editor";
+
+type GroupEditDialogProps = {
+  depth: number;
+  group: ButtonConfig;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (group: ButtonConfig) => void;
+  title: string;
+};
+
+export const GroupEditDialog = ({
+  depth,
+  group,
+  isOpen,
+  onClose,
+  onSave,
+  title,
+}: GroupEditDialogProps) => {
+  const [localGroup, setLocalGroup] = useState(group);
+
+  const handleSave = () => {
+    onSave(localGroup);
+    onClose();
+  };
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  return (
+    <Dialog onOpenChange={onClose} open={isOpen}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Edit Group: {title}</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <FormLabel htmlFor="group-name">Group Name</FormLabel>
+              <Input
+                id="group-name"
+                onChange={(e) => setLocalGroup({ ...localGroup, name: e.target.value })}
+                placeholder="Group name"
+                value={localGroup.name}
+              />
+              <Checkbox
+                checked={localGroup.executeAll || false}
+                id="execute-all"
+                label="Execute all commands simultaneously"
+                onCheckedChange={(checked) =>
+                  setLocalGroup({ ...localGroup, executeAll: !!checked })
+                }
+              />
+            </div>
+
+            <GroupCommandEditor
+              commands={localGroup.group || []}
+              depth={depth + 1}
+              onChange={(commands) => setLocalGroup({ ...localGroup, group: commands })}
+              title={`${title} Commands`}
+            />
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <Button onClick={handleCancel} type="button" variant="outline">
+            Cancel
+          </Button>
+          <Button onClick={handleSave} type="button">
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
- Extracted CommandCard component from command-list.tsx (83 lines)
- Extracted GroupEditDialog component from group-command-editor.tsx (74 lines)
- Updated import paths to use new separated components
- Followed React principle of one exported component per file

fix #83