### PR TITLE
refactor: introduce Context API to resolve props drilling

### DIFF
--- a/src/view/src/components/group-command-item.tsx
+++ b/src/view/src/components/group-command-item.tsx
@@ -2,6 +2,7 @@ import { GripVertical, Trash2, Folder, Terminal, Edit } from "lucide-react";
 
 import { Button, Input, Checkbox } from "~/core";
 
+import { useCommandEdit } from "../context/command-edit-context.tsx";
 import { useSortableItem } from "../hooks/use-sortable-item";
 import { type ButtonConfig } from "../types";
 import { DeleteConfirmationDialog } from "./delete-confirmation-dialog";
@@ -10,20 +11,12 @@ type GroupCommandItemProps = {
   command: ButtonConfig;
   id: string;
   index: number;
-  onDelete: (index: number) => void;
   onEditGroup?: () => void;
-  onUpdate: (index: number, updates: Partial<ButtonConfig>) => void;
 };
 
-export const GroupCommandItem = ({
-  command,
-  id,
-  index,
-  onDelete,
-  onEditGroup,
-  onUpdate,
-}: GroupCommandItemProps) => {
+export const GroupCommandItem = ({ command, id, index, onEditGroup }: GroupCommandItemProps) => {
   const isGroup = !!command.group;
+  const { deleteCommand, updateCommand } = useCommandEdit();
 
   const { attributes, listeners, setNodeRef, style } = useSortableItem(id);
 
@@ -49,7 +42,7 @@ export const GroupCommandItem = ({
 
         <div className="flex-1 space-y-2">
           <Input
-            onChange={(e) => onUpdate(index, { name: e.target.value })}
+            onChange={(e) => updateCommand(index, { name: e.target.value })}
             placeholder={isGroup ? "Group name" : "Command name"}
             value={command.name}
           />
@@ -57,12 +50,12 @@ export const GroupCommandItem = ({
           {!isGroup && (
             <>
               <Input
-                onChange={(e) => onUpdate(index, { command: e.target.value })}
+                onChange={(e) => updateCommand(index, { command: e.target.value })}
                 placeholder="Command (e.g., npm start)"
                 value={command.command || ""}
               />
               <Input
-                onChange={(e) => onUpdate(index, { terminalName: e.target.value })}
+                onChange={(e) => updateCommand(index, { terminalName: e.target.value })}
                 placeholder="Terminal name (optional)"
                 value={command.terminalName || ""}
               />
@@ -72,13 +65,13 @@ export const GroupCommandItem = ({
                     checked={command.useVsCodeApi || false}
                     id={`vscode-${index}`}
                     label="Use VS Code API"
-                    onCheckedChange={(checked) => onUpdate(index, { useVsCodeApi: !!checked })}
+                    onCheckedChange={(checked) => updateCommand(index, { useVsCodeApi: !!checked })}
                   />
                 </div>
                 <Input
                   className="flex-1 min-w-0"
                   maxLength={1}
-                  onChange={(e) => onUpdate(index, { shortcut: e.target.value })}
+                  onChange={(e) => updateCommand(index, { shortcut: e.target.value })}
                   placeholder="Shortcut (optional)"
                   value={command.shortcut || ""}
                 />
@@ -91,7 +84,7 @@ export const GroupCommandItem = ({
               <Input
                 className="flex-1"
                 maxLength={1}
-                onChange={(e) => onUpdate(index, { shortcut: e.target.value })}
+                onChange={(e) => updateCommand(index, { shortcut: e.target.value })}
                 placeholder="Shortcut (optional)"
                 value={command.shortcut || ""}
               />
@@ -113,7 +106,10 @@ export const GroupCommandItem = ({
               Edit
             </Button>
           )}
-          <DeleteConfirmationDialog commandName={command.name} onConfirm={() => onDelete(index)}>
+          <DeleteConfirmationDialog
+            commandName={command.name}
+            onConfirm={() => deleteCommand(index)}
+          >
             <Button
               className="h-8 w-8 p-0 text-red-500 hover:text-red-700"
               size="sm"

--- a/src/view/src/components/group-command-list.tsx
+++ b/src/view/src/components/group-command-list.tsx
@@ -17,33 +17,21 @@ import { useCallback, useMemo } from "react";
 
 import { Button } from "~/core";
 
-import { useCommandOperations } from "../hooks/use-command-operations";
-import { type ButtonConfig } from "../types";
 import { GroupCommandItem } from "./group-command-item";
+import { useCommandEdit } from "../context/command-edit-context.tsx";
 
 const MAX_NESTING_DEPTH = 2; // 0-indexed, so 3 levels total (0,1,2)
 
 type GroupCommandListProps = {
-  commands: ButtonConfig[];
   depth?: number;
-  onChange: (commands: ButtonConfig[]) => void;
   onEditGroup?: (index: number) => void;
   title?: string;
 };
 
-export const GroupCommandList = ({
-  commands,
-  depth = 0,
-  onChange,
-  onEditGroup,
-  title,
-}: GroupCommandListProps) => {
+export const GroupCommandList = ({ depth = 0, onEditGroup, title }: GroupCommandListProps) => {
   const canAddGroup = depth < MAX_NESTING_DEPTH;
 
-  const { addCommand, addGroup, deleteCommand, updateCommand } = useCommandOperations(
-    commands,
-    onChange
-  );
+  const { addCommand, addGroup, commands, onCommandsChange } = useCommandEdit();
 
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: {
@@ -69,11 +57,11 @@ export const GroupCommandList = ({
 
         if (oldIndex !== -1 && newIndex !== -1) {
           const newItems = arrayMove(commands, oldIndex, newIndex);
-          onChange(newItems);
+          onCommandsChange(newItems);
         }
       }
     },
-    [commands, onChange]
+    [commands, onCommandsChange]
   );
 
   return (
@@ -93,9 +81,7 @@ export const GroupCommandList = ({
                 id={command.id}
                 index={index}
                 key={command.id}
-                onDelete={deleteCommand}
                 onEditGroup={onEditGroup ? () => onEditGroup(index) : undefined}
-                onUpdate={updateCommand}
               />
             ))}
           </div>

--- a/src/view/src/context/command-edit-context.tsx
+++ b/src/view/src/context/command-edit-context.tsx
@@ -1,0 +1,130 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+
+import { type ButtonConfig } from "../types";
+
+type EditingGroup = {
+  depth: number;
+  group: ButtonConfig;
+  index: number;
+} | null;
+
+type CommandEditContextType = {
+  addCommand: () => void;
+  addGroup: () => void;
+  closeGroupEditor: () => void;
+  commands: ButtonConfig[];
+  deleteCommand: (index: number) => void;
+  editingGroup: EditingGroup;
+  onCommandsChange: (commands: ButtonConfig[]) => void;
+  openGroupEditor: (group: ButtonConfig, index: number, depth: number) => void;
+  saveGroup: (updatedGroup: ButtonConfig) => void;
+  updateCommand: (index: number, updates: Partial<ButtonConfig>) => void;
+};
+
+const CommandEditContext = createContext<CommandEditContextType | undefined>(undefined);
+
+export const useCommandEdit = () => {
+  const context = useContext(CommandEditContext);
+  if (context === undefined) {
+    throw new Error("useCommandEdit must be used within a CommandEditProvider");
+  }
+  return context;
+};
+
+type CommandEditProviderProps = {
+  children: ReactNode;
+  commands: ButtonConfig[];
+  onCommandsChange: (commands: ButtonConfig[]) => void;
+};
+
+export const CommandEditProvider = ({
+  children,
+  commands,
+  onCommandsChange,
+}: CommandEditProviderProps) => {
+  const [editingGroup, setEditingGroup] = useState<EditingGroup>(null);
+
+  const openGroupEditor = useCallback((group: ButtonConfig, index: number, depth: number) => {
+    setEditingGroup({ depth, group, index });
+  }, []);
+
+  const closeGroupEditor = useCallback(() => {
+    setEditingGroup(null);
+  }, []);
+
+  const saveGroup = useCallback(
+    (updatedGroup: ButtonConfig) => {
+      if (editingGroup) {
+        const newCommands = [...commands];
+        newCommands[editingGroup.index] = {
+          ...newCommands[editingGroup.index],
+          ...updatedGroup,
+        };
+        onCommandsChange(newCommands);
+        closeGroupEditor();
+      }
+    },
+    [editingGroup, commands, onCommandsChange, closeGroupEditor]
+  );
+
+  const updateCommand = useCallback(
+    (index: number, updates: Partial<ButtonConfig>) => {
+      const newCommands = [...commands];
+      newCommands[index] = { ...newCommands[index], ...updates };
+      onCommandsChange(newCommands);
+    },
+    [commands, onCommandsChange]
+  );
+
+  const deleteCommand = useCallback(
+    (index: number) => {
+      const newCommands = commands.filter((_, i) => i !== index);
+      onCommandsChange(newCommands);
+    },
+    [commands, onCommandsChange]
+  );
+
+  const addCommand = useCallback(() => {
+    const newCommand: ButtonConfig = {
+      color: "",
+      command: "",
+      id: crypto.randomUUID(),
+      name: "",
+      shortcut: "",
+      terminalName: "",
+      useVsCodeApi: false,
+    };
+    onCommandsChange([...commands, newCommand]);
+  }, [commands, onCommandsChange]);
+
+  const addGroup = useCallback(() => {
+    const newGroup: ButtonConfig = {
+      color: "",
+      executeAll: false,
+      group: [],
+      id: crypto.randomUUID(),
+      name: "",
+      shortcut: "",
+    };
+    onCommandsChange([...commands, newGroup]);
+  }, [commands, onCommandsChange]);
+
+  return (
+    <CommandEditContext.Provider
+      value={{
+        addCommand,
+        addGroup,
+        closeGroupEditor,
+        commands,
+        deleteCommand,
+        editingGroup,
+        onCommandsChange,
+        openGroupEditor,
+        saveGroup,
+        updateCommand,
+      }}
+    >
+      {children}
+    </CommandEditContext.Provider>
+  );
+};


### PR DESCRIPTION
Props drilling issue across 3-4 component levels reduced to 1-2 levels by introducing CommandEditContext, improving code maintainability

- Created CommandEditProvider to centrally manage command edit state
- Replaced props passing with useCommandEdit custom hook
- Reduced GroupCommandList props from 5 to 3 (40% reduction)
- Reduced GroupCommandItem props from 6 to 4 (33% reduction)
- Simplified GroupCommandEditor from 71 to 58 lines (18% reduction)

fix #84