### PR TITLE
refactor: improve GroupCommandList API with Compound Component pattern

### DIFF
--- a/src/view/src/components/group-command-editor.tsx
+++ b/src/view/src/components/group-command-editor.tsx
@@ -40,7 +40,11 @@ const GroupCommandEditorContent = ({ depth = 0, title }: { depth?: number; title
 
   return (
     <div className="space-y-4">
-      <GroupCommandList depth={depth} onEditGroup={editGroup} title={title} />
+      <GroupCommandList depth={depth} onEditGroup={editGroup}>
+        {title && <GroupCommandList.Title>{title}</GroupCommandList.Title>}
+        <GroupCommandList.Items />
+        <GroupCommandList.Actions />
+      </GroupCommandList>
 
       {editingGroup && (
         <GroupEditDialog

--- a/src/view/src/components/group-command-list.tsx
+++ b/src/view/src/components/group-command-list.tsx
@@ -13,7 +13,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { Plus, FolderPlus } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
 
 import { Button } from "~/core";
 
@@ -22,16 +22,52 @@ import { useCommandEdit } from "../context/command-edit-context.tsx";
 
 const MAX_NESTING_DEPTH = 2; // 0-indexed, so 3 levels total (0,1,2)
 
-type GroupCommandListProps = {
-  depth?: number;
+type GroupCommandListContextValue = {
+  depth: number;
   onEditGroup?: (index: number) => void;
-  title?: string;
 };
 
-export const GroupCommandList = ({ depth = 0, onEditGroup, title }: GroupCommandListProps) => {
-  const canAddGroup = depth < MAX_NESTING_DEPTH;
+const GroupCommandListContext = createContext<GroupCommandListContextValue | undefined>(undefined);
 
-  const { addCommand, addGroup, commands, onCommandsChange } = useCommandEdit();
+const useGroupCommandListContext = () => {
+  const context = useContext(GroupCommandListContext);
+  if (!context) {
+    throw new Error("GroupCommandList sub-components must be used within GroupCommandList");
+  }
+  return context;
+};
+
+type GroupCommandListProps = {
+  children: ReactNode;
+  depth?: number;
+  onEditGroup?: (index: number) => void;
+};
+
+const GroupCommandListRoot = ({ children, depth = 0, onEditGroup }: GroupCommandListProps) => {
+  const contextValue = useMemo(() => ({ depth, onEditGroup }), [depth, onEditGroup]);
+
+  return (
+    <GroupCommandListContext.Provider value={contextValue}>
+      <div className="space-y-4">{children}</div>
+    </GroupCommandListContext.Provider>
+  );
+};
+
+type TitleProps = {
+  children: ReactNode;
+};
+
+const Title = ({ children }: TitleProps) => {
+  return (
+    <div className="text-sm font-medium text-foreground pb-2 border-b border-border">
+      {children}
+    </div>
+  );
+};
+
+const Items = () => {
+  const { onEditGroup } = useGroupCommandListContext();
+  const { commands, onCommandsChange } = useCommandEdit();
 
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: {
@@ -65,41 +101,47 @@ export const GroupCommandList = ({ depth = 0, onEditGroup, title }: GroupCommand
   );
 
   return (
-    <div className="space-y-4">
-      {title && (
-        <div className="text-sm font-medium text-foreground pb-2 border-b border-border">
-          {title}
+    <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd} sensors={sensors}>
+      <SortableContext items={sortableItemIds} strategy={verticalListSortingStrategy}>
+        <div className="space-y-3">
+          {commands.map((command, index) => (
+            <GroupCommandItem
+              command={command}
+              id={command.id}
+              index={index}
+              key={command.id}
+              onEditGroup={onEditGroup ? () => onEditGroup(index) : undefined}
+            />
+          ))}
         </div>
-      )}
+      </SortableContext>
+    </DndContext>
+  );
+};
 
-      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd} sensors={sensors}>
-        <SortableContext items={sortableItemIds} strategy={verticalListSortingStrategy}>
-          <div className="space-y-3">
-            {commands.map((command, index) => (
-              <GroupCommandItem
-                command={command}
-                id={command.id}
-                index={index}
-                key={command.id}
-                onEditGroup={onEditGroup ? () => onEditGroup(index) : undefined}
-              />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
+const Actions = () => {
+  const { depth } = useGroupCommandListContext();
+  const { addCommand, addGroup } = useCommandEdit();
+  const canAddGroup = depth < MAX_NESTING_DEPTH;
 
-      <div className="flex gap-2">
-        <Button className="flex-1" onClick={addCommand} type="button" variant="outline">
-          <Plus className="mr-2" size={16} />
-          Add Command
+  return (
+    <div className="flex gap-2">
+      <Button className="flex-1" onClick={addCommand} type="button" variant="outline">
+        <Plus className="mr-2" size={16} />
+        Add Command
+      </Button>
+      {canAddGroup && (
+        <Button className="flex-1" onClick={addGroup} type="button" variant="outline">
+          <FolderPlus className="mr-2" size={16} />
+          Add Group
         </Button>
-        {canAddGroup && (
-          <Button className="flex-1" onClick={addGroup} type="button" variant="outline">
-            <FolderPlus className="mr-2" size={16} />
-            Add Group
-          </Button>
-        )}
-      </div>
+      )}
     </div>
   );
 };
+
+export const GroupCommandList = Object.assign(GroupCommandListRoot, {
+  Actions,
+  Items,
+  Title,
+});


### PR DESCRIPTION
- Remove title from optional props, replace with composition approach
- Eliminate props drilling through Context API-based state sharing
- Separate sub-components: GroupCommandList.Title/Items/Actions
- Enhance readability and flexibility with explicit composition at usage sites

fix #85