### PR TITLE
refactor: add success and warning variants to Button component and remove hardcoded styles

### DIFF
--- a/src/view/src/components/command-card.tsx
+++ b/src/view/src/components/command-card.tsx
@@ -76,8 +76,8 @@ export const CommandCard = ({ command, id, index }: CommandCardProps) => {
         </Button>
 
         <DeleteConfirmationDialog commandName={command.name} onConfirm={() => deleteCommand(index)}>
-          <Button className="p-2 hover:text-destructive" size="sm" variant="ghost">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <Button className="p-2" size="sm" variant="ghost">
+            <svg className="w-4 h-4 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
                 strokeLinecap="round"

--- a/src/view/src/components/group-command-item.tsx
+++ b/src/view/src/components/group-command-item.tsx
@@ -111,13 +111,13 @@ export const GroupCommandItem = ({ command, id, index, onEditGroup }: GroupComma
             onConfirm={() => deleteCommand(index)}
           >
             <Button
-              className="h-8 w-8 p-0 text-red-500 hover:text-red-700"
+              className="h-8 w-8 p-0"
               size="sm"
               title="Delete"
               type="button"
               variant="ghost"
             >
-              <Trash2 size={14} />
+              <Trash2 className="text-destructive" size={14} />
             </Button>
           </DeleteConfirmationDialog>
         </div>

--- a/src/view/src/components/header.tsx
+++ b/src/view/src/components/header.tsx
@@ -31,7 +31,7 @@ export const Header = () => {
             {isDark ? "☀️" : "🌙"}
           </Button>
           <Button onClick={openForm}>Add</Button>
-          <Button className="bg-green-600 hover:bg-green-700" onClick={saveConfig}>
+          <Button onClick={saveConfig} variant="success">
             Apply changes
           </Button>
         </div>

--- a/src/view/src/core/shadcn/button.tsx
+++ b/src/view/src/core/shadcn/button.tsx
@@ -27,6 +27,8 @@ const buttonVariants = cva(
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary: "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        success: "bg-green-600 text-white shadow-xs hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800",
+        warning: "bg-amber-600 text-white shadow-xs hover:bg-amber-700 dark:bg-amber-700 dark:hover:bg-amber-800",
       },
     },
   }


### PR DESCRIPTION
- Add success and warning variants to shadcn/ui Button for reusable styles
- Replace hardcoded Tailwind classes (bg-green-600, text-red-500, etc.) with variant/semantic colors
- Include dark mode support for theme consistency

fix #86