### PR TITLE
refactor: separate CommandForm component responsibilities with custom hooks

### DIFF
--- a/src/view/src/hooks/use-command-form-state.tsx
+++ b/src/view/src/hooks/use-command-form-state.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useState } from "react";
+
+import { type ButtonConfig } from "../types";
+
+type FormState = {
+  formData: ButtonConfig;
+  isGroupMode: boolean;
+};
+
+type FormActions = {
+  saveCommand: (onSave: (command: ButtonConfig) => void) => void;
+  setIsGroupMode: (isGroup: boolean) => void;
+  updateFormField: <K extends keyof ButtonConfig>(field: K, value: ButtonConfig[K]) => void;
+};
+
+const createInitialFormData = (
+  command?: (ButtonConfig & { index?: number }) | null
+): ButtonConfig => {
+  return (
+    command ?? {
+      color: "",
+      command: "",
+      executeAll: false,
+      group: [],
+      id: crypto.randomUUID(),
+      name: "",
+      shortcut: "",
+      terminalName: "",
+      useVsCodeApi: false,
+    }
+  );
+};
+
+export const useCommandFormState = (
+  command?: (ButtonConfig & { index?: number }) | null
+): FormState & FormActions => {
+  const [formData, setFormData] = useState<ButtonConfig>(() => createInitialFormData(command));
+  const [isGroupMode, setIsGroupMode] = useState(command?.group !== undefined);
+
+  const updateFormField = useCallback(
+    <K extends keyof ButtonConfig>(field: K, value: ButtonConfig[K]) => {
+      setFormData((prev) => ({ ...prev, [field]: value }));
+    },
+    []
+  );
+
+  const saveCommand = useCallback(
+    (onSave: (command: ButtonConfig) => void) => {
+      const commandConfig: ButtonConfig = {
+        color: formData.color || undefined,
+        id: formData.id,
+        name: formData.name.trim(),
+        shortcut: formData.shortcut || undefined,
+      };
+
+      if (isGroupMode) {
+        commandConfig.group = formData.group;
+        commandConfig.executeAll = formData.executeAll;
+      } else {
+        commandConfig.command = formData.command;
+        commandConfig.useVsCodeApi = formData.useVsCodeApi;
+        commandConfig.terminalName = formData.terminalName || undefined;
+      }
+
+      onSave(commandConfig);
+    },
+    [formData, isGroupMode]
+  );
+
+  return {
+    formData,
+    isGroupMode,
+    saveCommand,
+    setIsGroupMode,
+    updateFormField,
+  };
+};

--- a/src/view/src/hooks/use-command-form-validation.tsx
+++ b/src/view/src/hooks/use-command-form-validation.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useState } from "react";
+
+import { type ButtonConfig } from "../types";
+
+type ValidationResult = {
+  handleConfirmConversion: () => void;
+  handleSubmit: (e: React.FormEvent, onSave: () => void) => void;
+  setShowWarningDialog: (show: boolean) => void;
+  showWarningDialog: boolean;
+};
+
+type UseCommandFormValidationProps = {
+  formData: ButtonConfig;
+  isGroupMode: boolean;
+  originalIsGroupMode: boolean;
+};
+
+export const useCommandFormValidation = ({
+  formData,
+  isGroupMode,
+  originalIsGroupMode,
+}: UseCommandFormValidationProps): ValidationResult => {
+  const [showWarningDialog, setShowWarningDialog] = useState(false);
+  const [pendingSave, setPendingSave] = useState<(() => void) | null>(null);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent, onSave: () => void) => {
+      e.preventDefault();
+
+      // Validate required name field
+      if (!formData.name.trim()) return;
+
+      // Check if converting group to single command
+      const hasChildCommands = formData.group && formData.group.length > 0;
+      const isConvertingToSingle = originalIsGroupMode && !isGroupMode && hasChildCommands;
+
+      if (isConvertingToSingle) {
+        setPendingSave(() => onSave);
+        setShowWarningDialog(true);
+        return;
+      }
+
+      onSave();
+    },
+    [formData.name, formData.group, originalIsGroupMode, isGroupMode]
+  );
+
+  const handleConfirmConversion = useCallback(() => {
+    if (pendingSave) {
+      pendingSave();
+      setPendingSave(null);
+    }
+  }, [pendingSave]);
+
+  return {
+    handleConfirmConversion,
+    handleSubmit,
+    setShowWarningDialog,
+    showWarningDialog,
+  };
+};


### PR DESCRIPTION
- Reduced large 189-line component to 140 lines (26% reduction)
- Extracted validation logic into use-command-form-validation hook
- Extracted state management logic into use-command-form-state hook
- Improved single responsibility principle and testability

fix #87