### PR TITLE
refactor: apply adapter pattern to ConfigManager for architecture consistency

### DIFF
--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -3,6 +3,7 @@ import {
   createVSCodeConfigReader,
   createVSCodeStatusBarCreator,
   createVSCodeQuickPickCreator,
+  createVSCodeConfigWriter,
 } from "../internal/adapters";
 import { executeButtonCommand } from "../internal/command-executor";
 import { ConfigManager } from "../internal/managers/config-manager";
@@ -84,11 +85,12 @@ export const activate = (context: vscode.ExtensionContext) => {
   const configReader = createVSCodeConfigReader();
   const statusBarCreator = createVSCodeStatusBarCreator();
   const quickPickCreator = createVSCodeQuickPickCreator();
+  const configWriter = createVSCodeConfigWriter();
 
   const terminalManager = TerminalManager.create();
   const statusBarManager = StatusBarManager.create(configReader, statusBarCreator);
   const treeProvider = CommandTreeProvider.create(configReader);
-  const configManager = ConfigManager.create();
+  const configManager = ConfigManager.create(configWriter);
 
   statusBarManager.refreshButtons();
 

--- a/src/internal/adapters.ts
+++ b/src/internal/adapters.ts
@@ -30,6 +30,11 @@ export type StatusBarCreator = (
 
 export type QuickPickCreator = <T extends vscode.QuickPickItem>() => vscode.QuickPick<T>;
 
+export type ConfigWriter = {
+  writeButtons: (buttons: ButtonConfig[], target: vscode.ConfigurationTarget) => Promise<void>;
+  writeConfigurationTarget: (target: string) => Promise<void>;
+};
+
 const getButtonsFromConfig = (
   config: vscode.WorkspaceConfiguration
 ): ButtonConfigWithOptionalId[] => config.get("buttons") || [];
@@ -64,3 +69,14 @@ export const createVSCodeQuickPickCreator =
   (): QuickPickCreator =>
   <T extends vscode.QuickPickItem>() =>
     vscode.window.createQuickPick<T>();
+
+export const createVSCodeConfigWriter = (): ConfigWriter => ({
+  writeButtons: async (buttons: ButtonConfig[], target: vscode.ConfigurationTarget) => {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    await config.update("buttons", buttons, target);
+  },
+  writeConfigurationTarget: async (target: string) => {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    await config.update("configurationTarget", target, vscode.ConfigurationTarget.Global);
+  },
+});

--- a/src/internal/managers/config-manager.spec.ts
+++ b/src/internal/managers/config-manager.spec.ts
@@ -1,11 +1,17 @@
 import * as vscode from "vscode";
 import { CONFIGURATION_TARGETS } from "../../pkg/config-constants";
+import { ConfigWriter } from "../adapters";
 import { ConfigManager } from "./config-manager";
 
 describe("ConfigManager", () => {
   const createMockConfig = () => ({
     get: jest.fn(),
     update: jest.fn(),
+  });
+
+  const createMockConfigWriter = (): ConfigWriter => ({
+    writeButtons: jest.fn(),
+    writeConfigurationTarget: jest.fn(),
   });
 
   beforeEach(() => {
@@ -18,7 +24,8 @@ describe("ConfigManager", () => {
 
   describe("create", () => {
     it("should create ConfigManager instance", () => {
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       expect(configManager).toBeInstanceOf(ConfigManager);
     });
   });
@@ -31,7 +38,8 @@ describe("ConfigManager", () => {
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       const result = configManager.getCurrentConfigurationTarget();
 
       expect(result).toBe(CONFIGURATION_TARGETS.WORKSPACE);
@@ -48,7 +56,8 @@ describe("ConfigManager", () => {
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       const result = configManager.getCurrentConfigurationTarget();
 
       expect(result).toBe(CONFIGURATION_TARGETS.GLOBAL);
@@ -63,7 +72,8 @@ describe("ConfigManager", () => {
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       const result = configManager.getVSCodeConfigurationTarget();
 
       expect(result).toBe(vscode.ConfigurationTarget.Workspace);
@@ -76,7 +86,8 @@ describe("ConfigManager", () => {
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       const result = configManager.getVSCodeConfigurationTarget();
 
       expect(result).toBe(vscode.ConfigurationTarget.Global);
@@ -98,7 +109,8 @@ describe("ConfigManager", () => {
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       const result = configManager.getConfigDataForWebview(mockConfigReader);
 
       expect(result).toEqual({
@@ -114,16 +126,15 @@ describe("ConfigManager", () => {
       const mockButtons = [{ command: "echo test", id: "test-btn", name: "Test" }];
       const mockConfig = createMockConfig();
       mockConfig.get.mockReturnValue(CONFIGURATION_TARGETS.WORKSPACE);
-      mockConfig.update.mockResolvedValue(undefined);
       jest
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       await configManager.updateButtonConfiguration(mockButtons);
 
-      expect(mockConfig.update).toHaveBeenCalledWith(
-        "buttons",
+      expect(mockConfigWriter.writeButtons).toHaveBeenCalledWith(
         mockButtons,
         vscode.ConfigurationTarget.Workspace
       );
@@ -133,16 +144,15 @@ describe("ConfigManager", () => {
       const mockButtons = [{ command: "echo test", id: "test-btn", name: "Test" }];
       const mockConfig = createMockConfig();
       mockConfig.get.mockReturnValue(CONFIGURATION_TARGETS.GLOBAL);
-      mockConfig.update.mockResolvedValue(undefined);
       jest
         .spyOn(vscode.workspace, "getConfiguration")
         .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
 
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       await configManager.updateButtonConfiguration(mockButtons);
 
-      expect(mockConfig.update).toHaveBeenCalledWith(
-        "buttons",
+      expect(mockConfigWriter.writeButtons).toHaveBeenCalledWith(
         mockButtons,
         vscode.ConfigurationTarget.Global
       );
@@ -151,51 +161,23 @@ describe("ConfigManager", () => {
 
   describe("updateConfigurationTarget", () => {
     it("should update configuration target to global", async () => {
-      const mockConfig = createMockConfig();
-      mockConfig.update.mockResolvedValue(undefined);
-      jest
-        .spyOn(vscode.workspace, "getConfiguration")
-        .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
-
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       await configManager.updateConfigurationTarget(CONFIGURATION_TARGETS.GLOBAL);
 
-      expect(mockConfig.update).toHaveBeenCalledWith(
-        "configurationTarget",
-        CONFIGURATION_TARGETS.GLOBAL,
-        vscode.ConfigurationTarget.Global
+      expect(mockConfigWriter.writeConfigurationTarget).toHaveBeenCalledWith(
+        CONFIGURATION_TARGETS.GLOBAL
       );
     });
 
     it("should update configuration target to workspace", async () => {
-      const mockConfig = createMockConfig();
-      mockConfig.update.mockResolvedValue(undefined);
-      jest
-        .spyOn(vscode.workspace, "getConfiguration")
-        .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
-
-      const configManager = ConfigManager.create();
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
       await configManager.updateConfigurationTarget(CONFIGURATION_TARGETS.WORKSPACE);
 
-      expect(mockConfig.update).toHaveBeenCalledWith(
-        "configurationTarget",
-        CONFIGURATION_TARGETS.WORKSPACE,
-        vscode.ConfigurationTarget.Global
+      expect(mockConfigWriter.writeConfigurationTarget).toHaveBeenCalledWith(
+        CONFIGURATION_TARGETS.WORKSPACE
       );
-    });
-
-    it("should always use Global target for configurationTarget setting", async () => {
-      const mockConfig = createMockConfig();
-      mockConfig.update.mockResolvedValue(undefined);
-      jest
-        .spyOn(vscode.workspace, "getConfiguration")
-        .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
-
-      const configManager = ConfigManager.create();
-      await configManager.updateConfigurationTarget(CONFIGURATION_TARGETS.WORKSPACE);
-
-      const updateCall = mockConfig.update.mock.calls[0];
-      expect(updateCall[2]).toBe(vscode.ConfigurationTarget.Global);
     });
   });
 });

--- a/src/internal/managers/config-manager.ts
+++ b/src/internal/managers/config-manager.ts
@@ -7,14 +7,15 @@ import {
   ConfigurationTargetType,
 } from "../../pkg/config-constants";
 import { ButtonConfig } from "../../pkg/types";
+import { ConfigWriter } from "../adapters";
 
 type ConfigReader = { getButtons(): ButtonConfig[] };
 
 export class ConfigManager {
-  private constructor() {}
+  private constructor(private readonly configWriter: ConfigWriter) {}
 
-  static create(): ConfigManager {
-    return new ConfigManager();
+  static create(configWriter: ConfigWriter): ConfigManager {
+    return new ConfigManager(configWriter);
   }
 
   getConfigDataForWebview(configReader: ConfigReader): {
@@ -41,18 +42,11 @@ export class ConfigManager {
   }
 
   async updateButtonConfiguration(buttons: ButtonConfig[]): Promise<void> {
-    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
     const target = this.getVSCodeConfigurationTarget();
-
-    await config.update(CONFIG_KEYS.BUTTONS, buttons, target);
+    await this.configWriter.writeButtons(buttons, target);
   }
 
   async updateConfigurationTarget(target: ConfigurationTargetType): Promise<void> {
-    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
-    await config.update(
-      CONFIG_KEYS.CONFIGURATION_TARGET,
-      target,
-      vscode.ConfigurationTarget.Global // Configuration target setting itself should always be global
-    );
+    await this.configWriter.writeConfigurationTarget(target);
   }
 }


### PR DESCRIPTION
ConfigManager directly called VS Code API unlike other Managers, requiring global mocks in tests

- Added ConfigWriter type and createVSCodeConfigWriter() to adapters.ts
- Applied configWriter dependency injection to ConfigManager constructor
- Changed updateButtonConfiguration and updateConfigurationTarget methods to use Adapter
- Simplified test mocks: vscode.workspace global mock → ConfigWriter mock

fix #113