### PR TITLE
refactor: add error boundary for webview stability

### DIFF
--- a/src/view/package.json
+++ b/src/view/package.json
@@ -39,6 +39,7 @@
     "vite": "7.1.11"
   },
   "dependencies": {
+    "react-error-boundary": "^6.0.0",
     "sonner": "^2.0.7"
   }
 }

--- a/src/view/pnpm-lock.yaml
+++ b/src/view/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      react-error-boundary:
+        specifier: ^6.0.0
+        version: 6.0.0(react@19.1.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -215,6 +218,13 @@ packages:
     engines: { node: ">=6.9.0" }
     peerDependencies:
       "@babel/core": ^7.0.0-0
+
+  "@babel/runtime@7.28.4":
+    resolution:
+      {
+        integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==,
+      }
+    engines: { node: ">=6.9.0" }
 
   "@babel/template@7.27.2":
     resolution:
@@ -3118,6 +3128,14 @@ packages:
     peerDependencies:
       react: ^19.1.1
 
+  react-error-boundary@6.0.0:
+    resolution:
+      {
+        integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==,
+      }
+    peerDependencies:
+      react: ">=16.13.1"
+
   react-is@16.13.1:
     resolution:
       {
@@ -3802,6 +3820,8 @@ snapshots:
     dependencies:
       "@babel/core": 7.28.5
       "@babel/helper-plugin-utils": 7.27.1
+
+  "@babel/runtime@7.28.4": {}
 
   "@babel/template@7.27.2":
     dependencies:
@@ -5660,6 +5680,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       scheduler: 0.26.0
+
+  react-error-boundary@6.0.0(react@19.1.1):
+    dependencies:
+      "@babel/runtime": 7.28.4
+      react: 19.1.1
 
   react-is@16.13.1: {}
 

--- a/src/view/src/app.tsx
+++ b/src/view/src/app.tsx
@@ -1,5 +1,6 @@
 import { CommandFormDialog } from "./components/command-form-dialog.tsx";
 import { CommandList } from "./components/command-list.tsx";
+import { ErrorBoundary } from "./components/error-boundary.tsx";
 import { Header } from "./components/header";
 import { CommandFormProvider } from "./context/command-form-context.tsx";
 import { VscodeCommandProvider } from "./context/vscode-command-context.tsx";
@@ -7,18 +8,20 @@ import { Toaster } from "./core/toast";
 
 const App = () => {
   return (
-    <VscodeCommandProvider>
-      <CommandFormProvider>
-        <Toaster position="bottom-right" toastOptions={{ className: "text-sm" }} />
-        <div className="min-h-[100vh] bg-background p-6 text-foreground">
-          <div className="max-w-4xl mx-auto">
-            <Header />
-            <CommandList />
-            <CommandFormDialog />
+    <ErrorBoundary>
+      <VscodeCommandProvider>
+        <CommandFormProvider>
+          <Toaster position="bottom-right" toastOptions={{ className: "text-sm" }} />
+          <div className="min-h-[100vh] bg-background p-6 text-foreground">
+            <div className="max-w-4xl mx-auto">
+              <Header />
+              <CommandList />
+              <CommandFormDialog />
+            </div>
           </div>
-        </div>
-      </CommandFormProvider>
-    </VscodeCommandProvider>
+        </CommandFormProvider>
+      </VscodeCommandProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/view/src/components/error-boundary.tsx
+++ b/src/view/src/components/error-boundary.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { ErrorBoundary as ReactErrorBoundary, type FallbackProps } from "react-error-boundary";
+
+import { Button } from "~/core";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+const ERROR_MESSAGES = {
+  DESCRIPTION: "The configuration UI encountered an error.",
+  HEADING: "Something went wrong",
+  LOG_PREFIX: "Webview crashed:",
+  RELOAD_BUTTON: "Reload Webview",
+} as const;
+
+export const ErrorBoundary = ({ children }: ErrorBoundaryProps) => {
+  return (
+    <ReactErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onError={(error, info) => {
+        console.error(ERROR_MESSAGES.LOG_PREFIX, error, info.componentStack);
+      }}
+    >
+      {children}
+    </ReactErrorBoundary>
+  );
+};
+
+const ErrorFallback = ({ error }: FallbackProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen p-8">
+      <h2 className="text-xl font-bold mb-4">{ERROR_MESSAGES.HEADING}</h2>
+      <p className="text-muted-foreground mb-4">{ERROR_MESSAGES.DESCRIPTION}</p>
+      <p className="text-sm text-muted-foreground mb-6 font-mono bg-muted p-3 rounded max-w-lg overflow-auto">
+        {error.message}
+      </p>
+      <Button onClick={() => window.location.reload()}>{ERROR_MESSAGES.RELOAD_BUTTON}</Button>
+    </div>
+  );
+};


### PR DESCRIPTION
Prevent entire Webview crash on React component errors and provide recovery option

- Add ErrorBoundary component based on react-error-boundary library
- Display Fallback UI and Reload button on errors
- Wrap at top level to protect all child components

fix #116