### PR TITLE
feat: add VS Code theme synchronization for webview UI

### DIFF
--- a/src/internal/providers/webview-provider.spec.ts
+++ b/src/internal/providers/webview-provider.spec.ts
@@ -251,7 +251,9 @@ describe("webview-provider", () => {
       const webviewPath = "/test/missing/path";
       const expectedIndexPath = path.join(webviewPath, "index.html");
 
-      const accessSpy = jest.spyOn(fs.promises, "access").mockRejectedValue(new Error("File not found"));
+      const accessSpy = jest
+        .spyOn(fs.promises, "access")
+        .mockRejectedValue(new Error("File not found"));
 
       const result = await checkWebviewFilesExist(webviewPath);
 
@@ -264,7 +266,9 @@ describe("webview-provider", () => {
       const webviewPath = "";
       const expectedIndexPath = path.join(webviewPath, "index.html");
 
-      const accessSpy = jest.spyOn(fs.promises, "access").mockRejectedValue(new Error("File not found"));
+      const accessSpy = jest
+        .spyOn(fs.promises, "access")
+        .mockRejectedValue(new Error("File not found"));
 
       const result = await checkWebviewFilesExist(webviewPath);
 
@@ -329,7 +333,9 @@ describe("webview-provider", () => {
       const webviewPath = path.join(mockExtensionUri.fsPath, "src", "extension", "view-dist");
       const indexPath = path.join(webviewPath, "index.html");
 
-      const accessSpy = jest.spyOn(fs.promises, "access").mockRejectedValue(new Error("File not found"));
+      const accessSpy = jest
+        .spyOn(fs.promises, "access")
+        .mockRejectedValue(new Error("File not found"));
 
       const result = await buildWebviewHtml(mockExtensionUri, mockWebview);
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -19,6 +19,7 @@ export const MESSAGE_TYPE = {
   GET_CONFIG: "getConfig",
   SET_CONFIG: "setConfig",
   SET_CONFIGURATION_TARGET: "setConfigurationTarget",
+  THEME_CHANGED: "themeChanged",
 } as const;
 
 export const MESSAGES = {
@@ -53,3 +54,17 @@ export const TOAST_DURATION = {
   SUCCESS: 2000,
   TIMEOUT: 5000,
 } as const;
+
+/**
+ * VS Code ColorThemeKind enum values
+ * @see https://code.visualstudio.com/api/references/vscode-api#ColorThemeKind
+ * @see https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.d.ts
+ */
+export const COLOR_THEME_KIND = {
+  Dark: 2,
+  HighContrast: 3,
+  HighContrastLight: 4,
+  Light: 1,
+} as const;
+
+export type ColorThemeKind = (typeof COLOR_THEME_KIND)[keyof typeof COLOR_THEME_KIND];

--- a/src/view/src/style.css
+++ b/src/view/src/style.css
@@ -115,10 +115,10 @@
     @apply border-border outline-ring/50;
   }
   html {
-    @apply bg-background;
+    @apply bg-background transition-colors duration-200;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground transition-colors duration-200;
   }
 }
 


### PR DESCRIPTION
Detect VS Code theme changes in extension and automatically sync to webview

- Detect theme changes with onDidChangeActiveColorTheme event
- Send theme info to webview via window.postMessage
- Resend current theme when panel visibility changes
- Extract COLOR_THEME_KIND constants to shared constants for type safety

fix #117