### PR TITLE
chore: add VS Code debug environment for faster development cycle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension + Webview Watch",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/src/extension/out/**/*.js"],
+      "preLaunchTask": "compile + watch"
+    },
+    {
+      "name": "Extension Only",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/src/extension/out/**/*.js"],
+      "preLaunchTask": "pnpm: compile"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "cwd": "${workspaceFolder}",
+      "args": ["--runInBand", "--config", "src/extension/jest.config.cjs"],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["compile"],
+      "label": "pnpm: compile",
+      "problemMatcher": "$tsc"
+    },
+    {
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["build:watch"],
+      "label": "vite: watch",
+      "isBackground": true,
+      "options": {
+        "cwd": "${workspaceFolder}/src/view"
+      },
+      "problemMatcher": {
+        "owner": "vite",
+        "pattern": {
+          "regexp": "."
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "building for production",
+          "endsPattern": "built in"
+        }
+      }
+    },
+    {
+      "label": "compile + watch",
+      "dependsOn": ["pnpm: compile", "vite: watch"],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/src/view/package.json
+++ b/src/view/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
     "build": "tsc -b && vite build",
-    "preview": "vite preview",
-    "lint": "npx prettier --write \"src/**/*.{ts,tsx}\" && eslint --fix src/**/*.{ts,tsx}"
+    "build:watch": "vite build --watch",
+    "dev": "vite --host",
+    "lint": "npx prettier --write \"src/**/*.{ts,tsx}\" && eslint --fix src/**/*.{ts,tsx}",
+    "preview": "vite preview"
   },
   "devDependencies": {
     "@dnd-kit/core": "6.3.1",

--- a/src/view/vite.config.ts
+++ b/src/view/vite.config.ts
@@ -5,6 +5,10 @@ import tailwindcss from "@tailwindcss/vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  build: {
+    outDir: "../extension/view-dist",
+    emptyOutDir: true,
+  },
   resolve: {
     alias: {
       "~": "/src",


### PR DESCRIPTION
Enable instant testing of Extension and Webview with F5 key
- Add Extension debug configuration (.vscode/launch.json)
- Add TypeScript auto-compile and Vite watch tasks (.vscode/tasks.json)
- Add Vite watch mode for auto-rebuild on Webview changes (build:watch script)
- Fix Vite build output path to match Extension's read path (vite.config.ts)
- Add ESLint extension to recommended list (.vscode/extensions.json)

fix #118