### PR TITLE
perf(build): optimize VSIX package with esbuild bundling

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,108 +1,113 @@
-# Source code files - only include compiled output
+# Source files - only compiled output needed
 src/extension/main.ts
+src/extension/main.spec.ts
 src/extension/__mocks__/
 src/extension/*.test.ts
-src/extension/*.test.js
 src/extension/*.spec.ts
-src/extension/*.spec.js
 src/internal/
 src/pkg/
 src/shared/
 src/tests/
+src/global.d.ts
 
-# Development dependencies
-src/view/node_modules/
-src/node_modules/
-src/package.json
-src/pnpm-lock.yaml
-src/eslint.config.js
-
-# Exclude dev dependencies from extension package
-src/extension/node_modules/@jest/
-src/extension/node_modules/@babel/
-src/extension/node_modules/@types/
-src/extension/node_modules/typescript/
-src/extension/node_modules/jest/
-src/extension/node_modules/jest-*/
-src/extension/node_modules/ts-jest/
-src/extension/node_modules/@sinclair/
-src/extension/node_modules/@unrs/
-src/extension/node_modules/caniuse-lite/
-src/extension/node_modules/handlebars/
-src/extension/node_modules/uglify-js/
-
-# Development config files
+# Extension development files
 src/extension/tsconfig.json
-src/extension/jest.config.js
+src/extension/jest.config.cjs
 src/extension/.gitignore
-src/extension/yarn.lock
-src/extension/package-lock.json
+src/extension/.npmrc
+src/extension/pnpm-lock.yaml
+src/extension/package.json
+src/extension/coverage/
+src/extension/out/
+src/extension/LICENSE
 
-# View source (keep only built output in view-dist)
+# Extension node_modules - bundled via esbuild
+src/extension/node_modules/
+
+# Esbuild config
+esbuild.config.mjs
+
+# View source (built output in view-dist)
 src/view/
 
-# Root public folder - exclude large screenshots but keep logo
+# Root public folder - exclude screenshots
 public/screenshots/
 public/*.gif
-!public/logo.png
 
-# Root level dependencies
+# All node_modules
 node_modules/
+src/node_modules/
 .pnpm-store/
-frontend/
 
-# Development files
-.env
-.env.*
-!.env.example
-
-# VS Code specific
+# Development config files
+.vscode/
 .vscode-test/
 .vscode-test-web/
-
-# Git
-.git/
-.gitignore
-
-# Documentation and development (keep README for marketplace)
-CLAUDE.md
-
-# AI assistant configurations
-.claude/
-.gemini/
-.mcp.json
-
-# CI/CD
+.husky/
+.devcontainer/
 .github/
 .gitlab-ci.yml
 .travis.yml
 .circleci/
 
-# IDE files
+# Git
+.git/
+.gitignore
+
+# Documentation (keep README/CHANGELOG for marketplace)
+CLAUDE.md
+docs/
+
+# AI assistant configs
+.claude/
+.gemini/
+.mcp.json
+.playwright-mcp/
+
+# Development tools
+src/eslint.config.js
+eslint.config.js
+eslint.config.base.js
+.lintstagedrc.js
+.releaserc.js
+.prettierrc
+.prettierignore
+.npmrc
+justfile
+tsconfig.json
+tsconfig.base.json
+
+# Lock files
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# IDE/OS files
 .idea/
 *.swp
 *.swo
 *~
-
-# OS files
 .DS_Store
 Thumbs.db
 
-# Temporary files
+# Temp files
 tmp/
 temp/
 *.tmp
+*.log
 
 # Source maps
-*.map
+**/*.map
 
-# Other development files
-justfile
-.devcontainer/
+# Test files in output
+**/*.spec.js
+
+# Misc
+.vsixignore
 
 # Test coverage
 coverage/
 .nyc_output/
 
-# Logs
-*.log
+# Build artifacts
+*.vsix

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,0 +1,41 @@
+import * as esbuild from 'esbuild';
+
+const production = process.argv.includes('--production');
+const watch = process.argv.includes('--watch');
+
+/** @type {import('esbuild').BuildOptions} */
+const buildOptions = {
+  entryPoints: ['src/extension/main.ts'],
+  bundle: true,
+  outfile: 'dist/extension.js',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'node',
+  target: 'ES2020',
+  sourcemap: !production,
+  minify: production,
+  treeShaking: true,
+  // Resolve paths correctly
+  absWorkingDir: process.cwd(),
+  alias: {
+    // Map internal imports
+  },
+  // Node modules resolution
+  nodePaths: ['src/extension/node_modules', 'src/node_modules', 'node_modules'],
+};
+
+async function build() {
+  if (watch) {
+    const ctx = await esbuild.context(buildOptions);
+    await ctx.watch();
+    console.log('Watching for changes...');
+  } else {
+    await esbuild.build(buildOptions);
+    console.log(production ? 'Production build complete' : 'Development build complete');
+  }
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/justfile
+++ b/justfile
@@ -50,8 +50,6 @@ lint target="all":
     esac
 
 package: clean-build
-    pnpm build
-    pnpm compile
     pnpm package
 
 publish target="both":

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "activationEvents": [
     "onStartupFinished"
   ],
-  "main": "./src/extension/out/extension/main.js",
+  "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
@@ -263,10 +263,12 @@
     }
   },
   "scripts": {
-    "build": "cd src/view && pnpm build",
-    "build:extension": "cd src/extension && tsc -p ./",
+    "build": "pnpm build:view && pnpm build:extension",
+    "build:extension": "node esbuild.config.mjs --production",
+    "build:extension:dev": "node esbuild.config.mjs",
+    "build:extension:watch": "node esbuild.config.mjs --watch",
     "build:view": "cd src/view && pnpm build",
-    "compile": "pnpm build:extension",
+    "compile": "cd src/extension && tsc -p ./",
     "dev": "cd src/view && pnpm dev",
     "install-package": "code --install-extension quick-command-buttons-$npm_package_version.vsix",
     "lint": "pnpm lint:format && pnpm lint:extension && pnpm lint:view",
@@ -275,7 +277,7 @@
     "lint:format": "npx prettier --write \"src/{extension,internal,pkg,shared}/**/*.ts\" \"src/view/src/**/*.{ts,tsx}\" \"**/*.{json,yml,yaml,md}\"",
     "lint:view": "cd src/view && npx eslint --fix src/**/*.{ts,tsx}",
     "ovsx-publish": "ovsx publish --no-dependencies",
-    "package": "vsce package --no-dependencies --allow-star-activation && find . -maxdepth 1 -name '*.vsix' ! -name '*'$npm_package_version'.vsix' -delete",
+    "package": "pnpm build && vsce package --no-dependencies --allow-star-activation && find . -maxdepth 1 -name '*.vsix' ! -name '*'$npm_package_version'.vsix' -delete",
     "prepare": "husky",
     "preview": "cd src/view && pnpm preview",
     "test": "cd src/extension && jest",
@@ -299,6 +301,7 @@
     "@types/vscode": "1.90.0",
     "@vscode/vsce": "3.6.2",
     "conventional-changelog-conventionalcommits": "8.0.0",
+    "esbuild": "0.27.0",
     "eslint": "9.37.0",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-perfectionist": "4.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       conventional-changelog-conventionalcommits:
         specifier: 8.0.0
         version: 8.0.0
+      esbuild:
+        specifier: 0.27.0
+        version: 0.27.0
       eslint:
         specifier: 9.37.0
         version: 9.37.0
@@ -81,7 +84,7 @@ importers:
         version: 24.2.0(typescript@5.8.3)
       ts-jest:
         specifier: 29.4.1
-        version: 29.4.1(@babel/core@7.28.5)(@jest/transform@30.1.2)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.1.3(@types/node@24.3.0))(typescript@5.8.3)
+        version: 29.4.1(@babel/core@7.28.5)(@jest/transform@30.1.2)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.28.5))(esbuild@0.27.0)(jest-util@30.2.0)(jest@30.1.3(@types/node@24.3.0))(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -497,6 +500,240 @@ packages:
       {
         integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==,
       }
+
+  "@esbuild/aix-ppc64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
+  "@esbuild/android-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm@0.27.0":
+    resolution:
+      {
+        integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
+  "@esbuild/android-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/darwin-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/freebsd-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/linux-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.27.0":
+    resolution:
+      {
+        integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-ia32@0.27.0":
+    resolution:
+      {
+        integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-mips64el@0.27.0":
+    resolution:
+      {
+        integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-riscv64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.27.0":
+    resolution:
+      {
+        integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
+  "@esbuild/netbsd-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@esbuild/openbsd-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@esbuild/openharmony-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/sunos-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
+  "@esbuild/win32-arm64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-ia32@0.27.0":
+    resolution:
+      {
+        integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.27.0":
+    resolution:
+      {
+        integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
 
   "@eslint-community/eslint-utils@4.9.0":
     resolution:
@@ -2975,6 +3212,14 @@ packages:
         integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
       }
     engines: { node: ">= 0.4" }
+
+  esbuild@0.27.0:
+    resolution:
+      {
+        integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   escalade@3.2.0:
     resolution:
@@ -7486,6 +7731,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@esbuild/aix-ppc64@0.27.0":
+    optional: true
+
+  "@esbuild/android-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/android-arm@0.27.0":
+    optional: true
+
+  "@esbuild/android-x64@0.27.0":
+    optional: true
+
+  "@esbuild/darwin-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/darwin-x64@0.27.0":
+    optional: true
+
+  "@esbuild/freebsd-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.27.0":
+    optional: true
+
+  "@esbuild/linux-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/linux-arm@0.27.0":
+    optional: true
+
+  "@esbuild/linux-ia32@0.27.0":
+    optional: true
+
+  "@esbuild/linux-loong64@0.27.0":
+    optional: true
+
+  "@esbuild/linux-mips64el@0.27.0":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.27.0":
+    optional: true
+
+  "@esbuild/linux-riscv64@0.27.0":
+    optional: true
+
+  "@esbuild/linux-s390x@0.27.0":
+    optional: true
+
+  "@esbuild/linux-x64@0.27.0":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/netbsd-x64@0.27.0":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/openbsd-x64@0.27.0":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/sunos-x64@0.27.0":
+    optional: true
+
+  "@esbuild/win32-arm64@0.27.0":
+    optional: true
+
+  "@esbuild/win32-ia32@0.27.0":
+    optional: true
+
+  "@esbuild/win32-x64@0.27.0":
+    optional: true
+
   "@eslint-community/eslint-utils@4.9.0(eslint@9.37.0)":
     dependencies:
       eslint: 9.37.0
@@ -9265,6 +9588,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.27.0
+      "@esbuild/android-arm": 0.27.0
+      "@esbuild/android-arm64": 0.27.0
+      "@esbuild/android-x64": 0.27.0
+      "@esbuild/darwin-arm64": 0.27.0
+      "@esbuild/darwin-x64": 0.27.0
+      "@esbuild/freebsd-arm64": 0.27.0
+      "@esbuild/freebsd-x64": 0.27.0
+      "@esbuild/linux-arm": 0.27.0
+      "@esbuild/linux-arm64": 0.27.0
+      "@esbuild/linux-ia32": 0.27.0
+      "@esbuild/linux-loong64": 0.27.0
+      "@esbuild/linux-mips64el": 0.27.0
+      "@esbuild/linux-ppc64": 0.27.0
+      "@esbuild/linux-riscv64": 0.27.0
+      "@esbuild/linux-s390x": 0.27.0
+      "@esbuild/linux-x64": 0.27.0
+      "@esbuild/netbsd-arm64": 0.27.0
+      "@esbuild/netbsd-x64": 0.27.0
+      "@esbuild/openbsd-arm64": 0.27.0
+      "@esbuild/openbsd-x64": 0.27.0
+      "@esbuild/openharmony-arm64": 0.27.0
+      "@esbuild/sunos-x64": 0.27.0
+      "@esbuild/win32-arm64": 0.27.0
+      "@esbuild/win32-ia32": 0.27.0
+      "@esbuild/win32-x64": 0.27.0
 
   escalade@3.2.0: {}
 
@@ -11619,7 +11971,7 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-jest@29.4.1(@babel/core@7.28.5)(@jest/transform@30.1.2)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.1.3(@types/node@24.3.0))(typescript@5.8.3):
+  ts-jest@29.4.1(@babel/core@7.28.5)(@jest/transform@30.1.2)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.28.5))(esbuild@0.27.0)(jest-util@30.2.0)(jest@30.1.3(@types/node@24.3.0))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -11637,6 +11989,7 @@ snapshots:
       "@jest/transform": 30.1.2
       "@jest/types": 30.2.0
       babel-jest: 30.1.2(@babel/core@7.28.5)
+      esbuild: 0.27.0
       jest-util: 30.2.0
 
   tsconfig-paths@3.15.0:


### PR DESCRIPTION
Extension publishing included 946 files (5.6MB) causing performance warnings
Introduced esbuild bundling to optimize to 13 files (372KB)

- Add esbuild config for single-file extension.js bundling
- Update .vscodeignore to exclude unnecessary files
- Change package.json main entry to dist/extension.js
- Remove redundant build commands from justfile

fix #73