### PR TITLE
test: add configuration save and scope switch E2E tests

### DIFF
--- a/src/view/e2e/helpers/test-helpers.ts
+++ b/src/view/e2e/helpers/test-helpers.ts
@@ -85,3 +85,14 @@ export const waitForToast = async (page: Page, message?: string) => {
   await toast.waitFor({ state: "visible", timeout: TOAST_TIMEOUT });
   return toast;
 };
+
+/**
+ * Verify success toast message and wait for disappearance
+ */
+export const verifySuccessToast = async (page: Page, message: string) => {
+  const toast = page.locator('[data-sonner-toast]', { hasText: message });
+  await toast.waitFor({ state: "visible", timeout: TOAST_TIMEOUT });
+
+  // Wait for toast to disappear
+  await toast.waitFor({ state: "hidden", timeout: TOAST_TIMEOUT });
+};

--- a/src/view/e2e/save-configuration.spec.ts
+++ b/src/view/e2e/save-configuration.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { fillCommandForm, verifySuccessToast } from "./helpers/test-helpers";
+
+const NEW_COMMAND = {
+  color: "#9C27B0",
+  command: "npm run lint",
+  displayName: "Lint Code",
+  name: "$(wand) Lint Code",
+  shortcut: "l",
+};
+
+const SUCCESS_MESSAGE = "Configuration saved successfully";
+
+const createCommand = async (
+  page: Page,
+  command: {
+    name: string;
+    command: string;
+    color: string;
+    shortcut: string;
+  },
+) => {
+  await page.getByRole("button", { name: "Add new command" }).click();
+  await fillCommandForm(page, command);
+  await page.getByRole("button", { name: "Save" }).click();
+
+  // Extract display name for verification
+  const displayName = command.name.split(") ")[1] || command.name;
+  const commandCard = page.locator('[data-testid="command-card"]', {
+    hasText: displayName,
+  });
+  await expect(commandCard).toBeVisible();
+  return commandCard;
+};
+
+test.describe("Save Configuration with Apply Changes", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("should save configuration and show success toast message", async ({ page }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Add a new command (refer to Test 1)
+    await createCommand(page, NEW_COMMAND);
+
+    // When: Click "Apply changes" button
+    await page.getByRole("button", { name: "Apply configuration changes" }).click();
+
+    // Then: Verify toast notification appears with success message
+    await verifySuccessToast(page, SUCCESS_MESSAGE);
+  });
+
+  test("should save configuration after editing existing command", async ({ page }) => {
+    // Given: Create a new command first to ensure test independence
+    const testCard = await createCommand(page, {
+      name: "$(beaker) Edit Test Command",
+      command: "npm test",
+      color: "#FF5722",
+      shortcut: "edt",
+    });
+
+    // When: Edit the command we just created
+    await testCard.getByRole("button", { name: "Edit command" }).click();
+
+    // Change the command
+    const commandInput = page.getByRole("textbox", {
+      exact: true,
+      name: "Command",
+    });
+    await commandInput.clear();
+    await commandInput.fill("npm run test:coverage");
+
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // When: Apply changes
+    await page.getByRole("button", { name: "Apply configuration changes" }).click();
+
+    // Then: Verify toast notification
+    await verifySuccessToast(page, SUCCESS_MESSAGE);
+  });
+
+  test("should save configuration after deleting command", async ({ page }) => {
+    // Given: Create a new command first to ensure test independence
+    const temporaryCard = await createCommand(page, {
+      name: "$(trash) Temporary",
+      command: "echo temporary",
+      color: "#607D8B",
+      shortcut: "tmp",
+    });
+
+    // Get initial command count
+    const commandCards = page.locator('[data-testid="command-card"]');
+    const initialCount = await commandCards.count();
+
+    // When: Delete the command we just created
+    await temporaryCard.getByRole("button", { name: "Delete command" }).click();
+
+    // Confirm deletion
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    // Verify deletion occurred
+    const newCount = await commandCards.count();
+    expect(newCount).toBe(initialCount - 1);
+
+    // When: Apply changes
+    await page.getByRole("button", { name: "Apply configuration changes" }).click();
+
+    // Then: Verify toast notification
+    await verifySuccessToast(page, SUCCESS_MESSAGE);
+  });
+});

--- a/src/view/e2e/switch-configuration-scope.spec.ts
+++ b/src/view/e2e/switch-configuration-scope.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const UI_TEXT = {
+  WORKSPACE_DESCRIPTION: "Workspace: Project-specific commands shared with team",
+  WORKSPACE_SAVED_TO: "Saved to .vscode/settings.json",
+  GLOBAL_DESCRIPTION: "Global: Personal commands across all projects",
+  GLOBAL_SAVED_TO: "Saved to user settings",
+} as const;
+
+const BUTTON_NAMES = {
+  SWITCH_TO_GLOBAL: /Switch to Global settings/,
+  SWITCH_TO_WORKSPACE: /Switch to Workspace settings/,
+} as const;
+
+const BORDER_CLASSES = {
+  WORKSPACE: /border-l-amber-500/,
+  GLOBAL: /border-l-blue-500/,
+} as const;
+
+const switchToGlobal = async (page: Page) => {
+  const workspaceButton = page.getByRole("button", {
+    name: BUTTON_NAMES.SWITCH_TO_GLOBAL,
+  });
+  await workspaceButton.click();
+};
+
+const switchToWorkspace = async (page: Page) => {
+  const globalButton = page.getByRole("button", {
+    name: BUTTON_NAMES.SWITCH_TO_WORKSPACE,
+  });
+  await globalButton.click();
+};
+
+const verifyWorkspaceMode = async (page: Page) => {
+  const workspaceButton = page.getByRole("button", {
+    name: BUTTON_NAMES.SWITCH_TO_GLOBAL,
+  });
+  await expect(workspaceButton).toBeVisible();
+  await expect(workspaceButton).toContainText("Workspace");
+  await expect(page.getByText(UI_TEXT.WORKSPACE_DESCRIPTION)).toBeVisible();
+  await expect(page.getByText(UI_TEXT.WORKSPACE_SAVED_TO)).toBeVisible();
+
+  const configScopeSection = page.locator('[data-testid="config-scope-section"]');
+  await expect(configScopeSection).toHaveClass(BORDER_CLASSES.WORKSPACE);
+};
+
+const verifyGlobalMode = async (page: Page) => {
+  const globalButton = page.getByRole("button", {
+    name: BUTTON_NAMES.SWITCH_TO_WORKSPACE,
+  });
+  await expect(globalButton).toBeVisible();
+  await expect(globalButton).toContainText("Global");
+  await expect(page.getByText(UI_TEXT.GLOBAL_DESCRIPTION)).toBeVisible();
+  await expect(page.getByText(UI_TEXT.GLOBAL_SAVED_TO)).toBeVisible();
+
+  const configScopeSection = page.locator('[data-testid="config-scope-section"]');
+  await expect(configScopeSection).toHaveClass(BORDER_CLASSES.GLOBAL);
+};
+
+test.describe("Switch Workspace/Global Configuration", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("should switch between Workspace and Global configuration modes", async ({
+    page,
+  }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // Then: Verify initial state is Workspace mode
+    await verifyWorkspaceMode(page);
+
+    // When: Click Workspace button to switch to Global mode
+    await switchToGlobal(page);
+
+    // Then: Verify switched to Global mode
+    await verifyGlobalMode(page);
+
+    // When: Click Global button to switch back to Workspace mode
+    await switchToWorkspace(page);
+
+    // Then: Verify returned to Workspace mode
+    await verifyWorkspaceMode(page);
+  });
+
+  test("should display correct icons for each configuration mode", async ({
+    page,
+  }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // Then: Verify Workspace mode has folder icon and amber border
+    await verifyWorkspaceMode(page);
+
+    // When: Switch to Global mode
+    await switchToGlobal(page);
+
+    // Then: Verify Global mode has globe icon and blue border
+    await verifyGlobalMode(page);
+
+    // When: Switch back to Workspace
+    await switchToWorkspace(page);
+
+    // Then: Verify Workspace amber border is back
+    await verifyWorkspaceMode(page);
+  });
+
+  test("should persist configuration scope state across interactions", async ({
+    page,
+  }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Switch to Global mode
+    await switchToGlobal(page);
+
+    // Then: Verify Global mode is active
+    await verifyGlobalMode(page);
+
+    // When: Perform other actions (e.g., open and close add dialog)
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Then: Verify Global mode is still active (state persisted)
+    await verifyGlobalMode(page);
+  });
+});

--- a/src/view/src/components/header.tsx
+++ b/src/view/src/components/header.tsx
@@ -70,6 +70,7 @@ export const Header = () => {
           "border-l-[3px]",
           isWorkspace ? "border-l-amber-500" : "border-l-blue-500"
         )}
+        data-testid="config-scope-section"
       >
         <div className="flex flex-col gap-1">
           <span className="text-sm font-medium text-foreground">Configuration Scope</span>


### PR DESCRIPTION
Add E2E tests for configuration save and workspace/global scope switching

- save-configuration.spec.ts: verify toast notification after saving configuration
- switch-configuration-scope.spec.ts: verify workspace/global mode switching and UI indicators

fix #145