### PR TITLE
fix: configuration data not auto-reloading on scope switch

### DIFF
--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -88,9 +88,9 @@ export const activate = (context: vscode.ExtensionContext) => {
   const configWriter = createVSCodeConfigWriter();
 
   const terminalManager = TerminalManager.create();
-  const statusBarManager = StatusBarManager.create(configReader, statusBarCreator);
-  const treeProvider = CommandTreeProvider.create(configReader);
   const configManager = ConfigManager.create(configWriter);
+  const statusBarManager = StatusBarManager.create(configReader, statusBarCreator, configManager);
+  const treeProvider = CommandTreeProvider.create(configReader, configManager);
 
   statusBarManager.refreshButtons();
 

--- a/src/internal/adapters.ts
+++ b/src/internal/adapters.ts
@@ -19,6 +19,7 @@ export type TerminalExecutor = (
 
 export type ConfigReader = {
   getButtons: () => ButtonConfig[];
+  getButtonsFromScope: (target: vscode.ConfigurationTarget) => ButtonConfig[];
   getRefreshConfig: () => RefreshButtonConfig;
   onConfigChange: (listener: () => void) => vscode.Disposable;
 };
@@ -49,6 +50,19 @@ export const createVSCodeConfigReader = (): ConfigReader => ({
   getButtons: () => {
     const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
     const buttons = getButtonsFromConfig(config);
+    return ensureIdsInArray(buttons);
+  },
+  getButtonsFromScope: (target: vscode.ConfigurationTarget) => {
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    const inspection = config.inspect<ButtonConfigWithOptionalId[]>("buttons");
+
+    let buttons: ButtonConfigWithOptionalId[] = [];
+    if (target === vscode.ConfigurationTarget.Global) {
+      buttons = inspection?.globalValue || [];
+    } else if (target === vscode.ConfigurationTarget.Workspace) {
+      buttons = inspection?.workspaceValue || [];
+    }
+
     return ensureIdsInArray(buttons);
   },
   getRefreshConfig: () => {

--- a/src/internal/managers/config-manager.spec.ts
+++ b/src/internal/managers/config-manager.spec.ts
@@ -95,13 +95,14 @@ describe("ConfigManager", () => {
   });
 
   describe("getConfigDataForWebview", () => {
-    it("should return buttons and configuration target", () => {
+    it("should return buttons from workspace scope when configuration target is workspace", () => {
       const mockButtons = [
         { command: "echo test1", name: "Test 1" },
         { command: "echo test2", name: "Test 2" },
       ];
       const mockConfigReader = {
         getButtons: jest.fn().mockReturnValue(mockButtons),
+        getButtonsFromScope: jest.fn().mockReturnValue(mockButtons),
       };
       const mockConfig = createMockConfig();
       mockConfig.get.mockReturnValue(CONFIGURATION_TARGETS.WORKSPACE);
@@ -117,7 +118,34 @@ describe("ConfigManager", () => {
         buttons: mockButtons,
         configurationTarget: CONFIGURATION_TARGETS.WORKSPACE,
       });
-      expect(mockConfigReader.getButtons).toHaveBeenCalled();
+      expect(mockConfigReader.getButtonsFromScope).toHaveBeenCalledWith(
+        vscode.ConfigurationTarget.Workspace
+      );
+    });
+
+    it("should return buttons from global scope when configuration target is global", () => {
+      const mockGlobalButtons = [{ command: "echo global", name: "Global Command" }];
+      const mockConfigReader = {
+        getButtons: jest.fn().mockReturnValue([]),
+        getButtonsFromScope: jest.fn().mockReturnValue(mockGlobalButtons),
+      };
+      const mockConfig = createMockConfig();
+      mockConfig.get.mockReturnValue(CONFIGURATION_TARGETS.GLOBAL);
+      jest
+        .spyOn(vscode.workspace, "getConfiguration")
+        .mockReturnValue(mockConfig as unknown as vscode.WorkspaceConfiguration);
+
+      const mockConfigWriter = createMockConfigWriter();
+      const configManager = ConfigManager.create(mockConfigWriter);
+      const result = configManager.getConfigDataForWebview(mockConfigReader);
+
+      expect(result).toEqual({
+        buttons: mockGlobalButtons,
+        configurationTarget: CONFIGURATION_TARGETS.GLOBAL,
+      });
+      expect(mockConfigReader.getButtonsFromScope).toHaveBeenCalledWith(
+        vscode.ConfigurationTarget.Global
+      );
     });
   });
 

--- a/src/internal/managers/config-manager.ts
+++ b/src/internal/managers/config-manager.ts
@@ -9,7 +9,10 @@ import {
 import { ButtonConfig } from "../../pkg/types";
 import { ConfigWriter } from "../adapters";
 
-type ConfigReader = { getButtons(): ButtonConfig[] };
+type ConfigReader = {
+  getButtons(): ButtonConfig[];
+  getButtonsFromScope(target: vscode.ConfigurationTarget): ButtonConfig[];
+};
 
 export class ConfigManager {
   private constructor(private readonly configWriter: ConfigWriter) {}
@@ -22,9 +25,12 @@ export class ConfigManager {
     buttons: ButtonConfig[];
     configurationTarget: ConfigurationTargetType;
   } {
+    const currentTarget = this.getCurrentConfigurationTarget();
+    const vsCodeTarget = this.getVSCodeConfigurationTarget();
+
     return {
-      buttons: configReader.getButtons(),
-      configurationTarget: this.getCurrentConfigurationTarget(),
+      buttons: configReader.getButtonsFromScope(vsCodeTarget),
+      configurationTarget: currentTarget,
     };
   }
 

--- a/src/internal/managers/status-bar-manager.ts
+++ b/src/internal/managers/status-bar-manager.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { ButtonConfig } from "../../pkg/types";
 import { ConfigReader, StatusBarCreator } from "../adapters";
+import { ConfigManager } from "./config-manager";
 
 export const calculateButtonPriority = (index: number): number => {
   return 1000 - index;
@@ -37,13 +38,15 @@ export class StatusBarManager {
 
   constructor(
     private configReader: ConfigReader,
-    private statusBarCreator: StatusBarCreator
+    private statusBarCreator: StatusBarCreator,
+    private configManager: ConfigManager
   ) {}
 
   static create = (
     configReader: ConfigReader,
-    statusBarCreator: StatusBarCreator
-  ): StatusBarManager => new StatusBarManager(configReader, statusBarCreator);
+    statusBarCreator: StatusBarCreator,
+    configManager: ConfigManager
+  ): StatusBarManager => new StatusBarManager(configReader, statusBarCreator, configManager);
 
   dispose = () => {
     this.statusBarItems.forEach((item) => item.dispose());
@@ -57,7 +60,8 @@ export class StatusBarManager {
   };
 
   private createCommandButtons = () => {
-    const buttons = this.configReader.getButtons();
+    const target = this.configManager.getVSCodeConfigurationTarget();
+    const buttons = this.configReader.getButtonsFromScope(target);
 
     buttons.forEach((button, index) => {
       const statusBarItem = this.statusBarCreator(

--- a/src/internal/providers/command-tree-provider.ts
+++ b/src/internal/providers/command-tree-provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { ConfigReader, TerminalExecutor } from "../adapters";
+import { ConfigManager } from "../managers/config-manager";
 import { CommandTreeItem, GroupTreeItem, TreeItem, createTreeItems } from "../utils/ui-items";
 export { CommandTreeItem, GroupTreeItem };
 
@@ -7,10 +8,13 @@ export class CommandTreeProvider implements vscode.TreeDataProvider<TreeItem> {
   private _onDidChangeTreeData = new vscode.EventEmitter<TreeItem | undefined | null | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  constructor(private configReader: ConfigReader) {}
+  constructor(
+    private configReader: ConfigReader,
+    private configManager: ConfigManager
+  ) {}
 
-  static create = (configReader: ConfigReader): CommandTreeProvider =>
-    new CommandTreeProvider(configReader);
+  static create = (configReader: ConfigReader, configManager: ConfigManager): CommandTreeProvider =>
+    new CommandTreeProvider(configReader, configManager);
 
   static executeFromTree = (item: CommandTreeItem, terminalExecutor: TerminalExecutor) => {
     terminalExecutor(item.commandString, item.useVsCodeApi, item.terminalName, item.buttonName);
@@ -35,7 +39,8 @@ export class CommandTreeProvider implements vscode.TreeDataProvider<TreeItem> {
   };
 
   private getRootItems = (): TreeItem[] => {
-    const buttons = this.configReader.getButtons();
+    const target = this.configManager.getVSCodeConfigurationTarget();
+    const buttons = this.configReader.getButtonsFromScope(target);
     return createTreeItems(buttons);
   };
 }

--- a/src/internal/providers/webview-provider.ts
+++ b/src/internal/providers/webview-provider.ts
@@ -169,7 +169,7 @@ const initializeWebview = async (options: InitializeWebviewOptions): Promise<voi
   setupThemeSynchronization(webview, visibilityOptions, disposables);
 };
 
-const handleWebviewMessage = async (
+export const handleWebviewMessage = async (
   message: WebviewMessage,
   webview: vscode.Webview,
   configReader: ConfigReader,
@@ -202,8 +202,9 @@ const handleWebviewMessage = async (
         ) {
           await configManager.updateConfigurationTarget(message.target);
           webview.postMessage({
+            data: configManager.getConfigDataForWebview(configReader),
             requestId: message.requestId,
-            type: "success",
+            type: "configData",
           });
         } else {
           throw new Error(MESSAGES.ERROR.invalidConfigurationTarget(message.target ?? "undefined"));

--- a/src/view/e2e/add-group-command.spec.ts
+++ b/src/view/e2e/add-group-command.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { clearAllCommands } from "./helpers/test-helpers";
+
 const SELECTORS = {
   ADD_BUTTON: "Add new command",
   CLOSE_BUTTON: "Close",
@@ -37,9 +39,13 @@ const NEW_GROUP = {
 };
 
 test.describe("Add Group Command", () => {
-  test("should add a new group command with multiple child commands", async ({ page }) => {
-    // Given: Navigate to the configuration page
+  test.beforeEach(async ({ page }) => {
     await page.goto("/");
+    await clearAllCommands(page);
+  });
+
+  test("should add a new group command with multiple child commands", async ({ page }) => {
+    // Given: Empty state (from beforeEach)
 
     // Get initial count
     const commandCards = page.locator(SELECTORS.COMMAND_CARD);

--- a/src/view/e2e/add-single-command.spec.ts
+++ b/src/view/e2e/add-single-command.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { clearAllCommands } from "./helpers/test-helpers";
+
 const NEW_COMMAND = {
   name: "$(rocket) Build",
   displayName: "Build",
@@ -9,11 +11,15 @@ const NEW_COMMAND = {
 };
 
 test.describe("Test 1: Add Single Command", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await clearAllCommands(page);
+  });
+
   test("should add a new single command with all properties", async ({
     page,
   }) => {
-    // Given: Navigate to the configuration page
-    await page.goto("/");
+    // Given: Empty state (from beforeEach)
 
     // Get initial count
     const commandCards = page.locator('[data-testid="command-card"]');

--- a/src/view/e2e/convert-group-to-single.spec.ts
+++ b/src/view/e2e/convert-group-to-single.spec.ts
@@ -12,7 +12,7 @@ test.describe("Test 11: Convert Group to Single Command (Warning Shown)", () => 
   test("should show warning dialog when converting group with children to single command", async ({
     page,
   }) => {
-    // Given: Navigate to the configuration page
+    // Given: Navigate to the configuration page with Git fixture
     await page.goto("/");
 
     // When: Click Edit button for Git group

--- a/src/view/e2e/convert-single-to-group.spec.ts
+++ b/src/view/e2e/convert-single-to-group.spec.ts
@@ -10,7 +10,7 @@ const TEST_COMMAND = {
 
 test.describe("Test 10: Convert Single to Group Command (No Warning)", () => {
   test("should convert single command to group without warning dialog", async ({ page }) => {
-    // Given: Navigate to the configuration page
+    // Given: Navigate to the configuration page with Test fixture
     await page.goto("/");
 
     // When: Click Edit button for Test command

--- a/src/view/package.json
+++ b/src/view/package.json
@@ -46,6 +46,7 @@
     "@formkit/auto-animate": "0.9.0",
     "@hookform/resolvers": "5.2.2",
     "@vscode/codicons": "0.0.43",
+    "fast-deep-equal": "3.1.3",
     "motion": "12.23.24",
     "react-error-boundary": "6.0.0",
     "react-hook-form": "7.66.1",

--- a/src/view/pnpm-lock.yaml
+++ b/src/view/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       "@vscode/codicons":
         specifier: 0.0.43
         version: 0.0.43
+      fast-deep-equal:
+        specifier: 3.1.3
+        version: 3.1.3
       motion:
         specifier: 12.23.24
         version: 12.23.24(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
Problem:
- Webview, sidebar, and status bar continued displaying old data after switching between Global/Workspace scopes
- Commands saved in Global scope disappeared when switching back to Global
- Data loss occurred when switching scopes with unsaved changes

Solution:
- Server: setConfigurationTarget now returns configData response with new scope's data
- Client: implemented unsaved changes detection with "Save & Switch/Don't Save/Cancel" warning dialog
- Scope-specific data reading: added getButtonsFromScope() method to read specific scope instead of merged configuration
- UI synchronization: updated StatusBarManager and CommandTreeProvider to display only current scope's data

fix #153