### PR TITLE
feat: implement Local configuration scope functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ The extension follows a **dependency injection pattern** with clear separation o
 3. **Managers** (`src/internal/managers/`): Domain-specific business logic
    - `StatusBarManager`: Status bar button lifecycle and rendering
    - `TerminalManager`: Terminal creation and command execution
-   - `ConfigManager`: Configuration reading/writing across scopes
+   - `ConfigManager`: Configuration reading/writing with 3-tier fallback (Local → Workspace → Global)
 4. **Providers** (`src/internal/providers/`):
    - `CommandTreeProvider`: Sidebar tree view data provider
    - `ConfigWebviewProvider`: React-based configuration UI host
@@ -115,12 +115,23 @@ The extension supports 15 keyboard layouts via `src/internal/keyboard-layout-con
 
 ### Configuration Scopes
 
-Two configuration targets managed by `ConfigManager`:
+Three configuration scopes with automatic fallback (Local → Workspace → Global):
 
-- **Workspace**: `.vscode/settings.json` (team collaboration)
-- **Global**: User settings (personal commands)
+- **Local**: Project workspace state (personal, Git-excluded, devcontainer-isolated)
+- **Workspace**: `.vscode/settings.json` (team collaboration, Git-tracked)
+- **Global**: User settings (personal commands across all projects)
 
-Toggle via `quickCommandButtons.configurationTarget` setting.
+Select via Configuration UI or `quickCommandButtons.configurationTarget` setting.
+
+**Fallback Logic**: When buttons are not found in selected scope, automatically falls back to next scope:
+
+- Local (empty) → Workspace → Global
+- Workspace (empty) → Global
+
+**Storage**:
+
+- Local: `workspaceState` (SQLite, per-workspace isolation)
+- Workspace/Global: VS Code settings (JSON)
 
 ### Webview Architecture
 

--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ _Drag-and-drop configuration with real-time preview_
 
 ## ⚙️ Configuration Scope
 
-**📁 Workspace Settings** - Share project-specific commands with your team (saved to `.vscode/settings.json`)
-**🌐 Global Settings** - Personal commands available across all projects (saved to user settings)
+**💻 Local** - Personal project commands (Git-excluded, isolated per project/devcontainer)
+**📁 Workspace** - Team collaboration commands (saved to `.vscode/settings.json`, Git-tracked)
+**🌐 Global** - Personal commands across all projects (saved to user settings)
 
-Use `Ctrl+Shift+P` → `Toggle Configuration Target` or the button in Configuration UI to switch between scopes.
+Select scope in Configuration UI. Automatic fallback: Local → Workspace → Global when empty.
 
 ## 🎮 Usage Tips
 

--- a/package.json
+++ b/package.json
@@ -134,12 +134,14 @@
         "quickCommandButtons.configurationTarget": {
           "type": "string",
           "enum": [
+            "local",
             "workspace",
             "global"
           ],
           "default": "workspace",
-          "description": "Where to save button configurations: 'workspace' saves to .vscode/settings.json (project-specific), 'global' saves to user settings (shared across all projects)",
+          "description": "Where to save button configurations: 'local' saves to workspace state (Git-excluded), 'workspace' saves to .vscode/settings.json (project-specific), 'global' saves to user settings (shared across all projects)",
           "enumDescriptions": [
+            "Save to workspace state (Git-excluded) - personal project commands",
             "Save to workspace settings (.vscode/settings.json) - project-specific commands",
             "Save to user settings - shared across all projects"
           ]

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -4,6 +4,7 @@ import {
   createVSCodeStatusBarCreator,
   createVSCodeQuickPickCreator,
   createVSCodeConfigWriter,
+  createProjectLocalStorage,
 } from "../internal/adapters";
 import { executeButtonCommand } from "../internal/command-executor";
 import { ConfigManager } from "../internal/managers/config-manager";
@@ -14,6 +15,7 @@ import { ConfigWebviewProvider } from "../internal/providers/webview-provider";
 import { createShowAllCommandsCommand } from "../internal/show-all-commands";
 import { CONFIGURATION_TARGETS } from "../pkg/config-constants";
 import { ButtonConfig } from "../pkg/types";
+import { COMMANDS } from "../shared/constants";
 
 export const registerCommands = (
   context: vscode.ExtensionContext,
@@ -41,7 +43,7 @@ export const registerCommands = (
     () => treeProvider.refresh()
   );
 
-  const refreshCommand = vscode.commands.registerCommand("quickCommandButtons.refresh", () => {
+  const refreshCommand = vscode.commands.registerCommand(COMMANDS.REFRESH, () => {
     statusBarManager.refreshButtons();
     treeProvider.refresh();
     vscode.window.showInformationMessage("Quick Command Buttons refreshed!");
@@ -86,9 +88,10 @@ export const activate = (context: vscode.ExtensionContext) => {
   const statusBarCreator = createVSCodeStatusBarCreator();
   const quickPickCreator = createVSCodeQuickPickCreator();
   const configWriter = createVSCodeConfigWriter();
+  const localStorage = createProjectLocalStorage(context);
 
   const terminalManager = TerminalManager.create();
-  const configManager = ConfigManager.create(configWriter);
+  const configManager = ConfigManager.create(configWriter, localStorage);
   const statusBarManager = StatusBarManager.create(configReader, statusBarCreator, configManager);
   const treeProvider = CommandTreeProvider.create(configReader, configManager);
 

--- a/src/internal/adapters.ts
+++ b/src/internal/adapters.ts
@@ -9,6 +9,8 @@ const DEFAULT_REFRESH_CONFIG: RefreshButtonConfig = {
   icon: "$(refresh)",
 };
 
+export const LOCAL_BUTTONS_STORAGE_KEY = "quickCommandButtons.localButtons";
+
 export type TerminalExecutor = (
   command: string,
   useVsCodeApi?: boolean,
@@ -100,7 +102,17 @@ export const createVSCodeConfigWriter = (): ConfigWriter => ({
   },
 });
 
-export const createProjectLocalStorage = (): ProjectLocalStorage => ({
-  getButtons: () => [],
-  setButtons: async () => {},
-});
+export const createProjectLocalStorage = (
+  context: vscode.ExtensionContext
+): ProjectLocalStorage => {
+  return {
+    getButtons: () => {
+      const buttons =
+        context.workspaceState.get<ButtonConfigWithOptionalId[]>(LOCAL_BUTTONS_STORAGE_KEY) || [];
+      return ensureIdsInArray(buttons);
+    },
+    setButtons: async (buttons: ButtonConfig[]) => {
+      await context.workspaceState.update(LOCAL_BUTTONS_STORAGE_KEY, buttons);
+    },
+  };
+};

--- a/src/internal/managers/status-bar-manager.ts
+++ b/src/internal/managers/status-bar-manager.ts
@@ -60,8 +60,7 @@ export class StatusBarManager {
   };
 
   private createCommandButtons = () => {
-    const target = this.configManager.getVSCodeConfigurationTarget();
-    const buttons = this.configReader.getButtonsFromScope(target);
+    const { buttons } = this.configManager.getButtonsWithFallback(this.configReader);
 
     buttons.forEach((button, index) => {
       const statusBarItem = this.statusBarCreator(

--- a/src/internal/providers/command-tree-provider.ts
+++ b/src/internal/providers/command-tree-provider.ts
@@ -39,8 +39,7 @@ export class CommandTreeProvider implements vscode.TreeDataProvider<TreeItem> {
   };
 
   private getRootItems = (): TreeItem[] => {
-    const target = this.configManager.getVSCodeConfigurationTarget();
-    const buttons = this.configReader.getButtonsFromScope(target);
+    const { buttons } = this.configManager.getButtonsWithFallback(this.configReader);
     return createTreeItems(buttons);
   };
 }

--- a/src/internal/providers/webview-provider.ts
+++ b/src/internal/providers/webview-provider.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import { z } from "zod";
 import { CONFIGURATION_TARGETS } from "../../pkg/config-constants";
 import { WebviewMessage } from "../../pkg/types";
-import { MESSAGE_TYPE, MESSAGES } from "../../shared/constants";
+import { MESSAGE_TYPE, MESSAGES, COMMANDS } from "../../shared/constants";
 import { ConfigReader } from "../adapters";
 import { ConfigManager } from "../managers/config-manager";
 import { ButtonConfigWithOptionalId } from "../utils/ensure-id";
@@ -187,6 +187,7 @@ export const handleWebviewMessage = async (
       case "setConfig":
         if (isButtonConfigArray(message.data)) {
           await configManager.updateButtonConfiguration(message.data);
+          await vscode.commands.executeCommand(COMMANDS.REFRESH);
           webview.postMessage({
             requestId: message.requestId,
             type: "success",
@@ -198,7 +199,8 @@ export const handleWebviewMessage = async (
       case "setConfigurationTarget":
         if (
           message.target === CONFIGURATION_TARGETS.GLOBAL ||
-          message.target === CONFIGURATION_TARGETS.WORKSPACE
+          message.target === CONFIGURATION_TARGETS.WORKSPACE ||
+          message.target === CONFIGURATION_TARGETS.LOCAL
         ) {
           await configManager.updateConfigurationTarget(message.target);
           webview.postMessage({

--- a/src/pkg/config-constants.ts
+++ b/src/pkg/config-constants.ts
@@ -7,7 +7,6 @@ export const CONFIGURATION_TARGETS = CONFIGURATION_TARGET;
 
 export const VS_CODE_CONFIGURATION_TARGETS = {
   [CONFIGURATION_TARGETS.GLOBAL]: vscode.ConfigurationTarget.Global,
-  [CONFIGURATION_TARGETS.LOCAL]: vscode.ConfigurationTarget.Workspace,
   [CONFIGURATION_TARGETS.WORKSPACE]: vscode.ConfigurationTarget.Workspace,
 } as const;
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -56,6 +56,10 @@ export const TOAST_DURATION = {
   TIMEOUT: 5000,
 } as const;
 
+export const COMMANDS = {
+  REFRESH: "quickCommandButtons.refresh",
+} as const;
+
 /**
  * VS Code ColorThemeKind enum values
  * @see https://code.visualstudio.com/api/references/vscode-api#ColorThemeKind

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,7 +34,7 @@ export type WebviewMessage = {
 export type ConfigDataMessage = {
   data: {
     buttons: ButtonConfig[];
-    configurationTarget: string;
+    configurationTarget: ConfigurationTarget;
   };
   requestId?: string;
   type: "configData";

--- a/src/view/e2e/switch-configuration-scope.spec.ts
+++ b/src/view/e2e/switch-configuration-scope.spec.ts
@@ -1,61 +1,52 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-const UI_TEXT = {
-  WORKSPACE_DESCRIPTION: "Workspace: Project-specific commands shared with team",
-  WORKSPACE_SAVED_TO: "Saved to .vscode/settings.json",
-  GLOBAL_DESCRIPTION: "Global: Personal commands across all projects",
-  GLOBAL_SAVED_TO: "Saved to user settings",
-} as const;
-
 const BUTTON_NAMES = {
-  SWITCH_TO_GLOBAL: /Switch to Global settings/,
-  SWITCH_TO_WORKSPACE: /Switch to Workspace settings/,
-} as const;
-
-const BORDER_CLASSES = {
-  WORKSPACE: /border-l-amber-500/,
-  GLOBAL: /border-l-blue-500/,
+  SWITCH_TO_GLOBAL: /Global scope/,
+  SWITCH_TO_WORKSPACE: /Workspace scope/,
+  SWITCH_TO_LOCAL: /Local scope/,
 } as const;
 
 const switchToGlobal = async (page: Page) => {
-  const workspaceButton = page.getByRole("button", {
+  const globalButton = page.getByRole("radio", {
     name: BUTTON_NAMES.SWITCH_TO_GLOBAL,
-  });
-  await workspaceButton.click();
-};
-
-const switchToWorkspace = async (page: Page) => {
-  const globalButton = page.getByRole("button", {
-    name: BUTTON_NAMES.SWITCH_TO_WORKSPACE,
   });
   await globalButton.click();
 };
 
-const verifyWorkspaceMode = async (page: Page) => {
-  const workspaceButton = page.getByRole("button", {
-    name: BUTTON_NAMES.SWITCH_TO_GLOBAL,
+const switchToWorkspace = async (page: Page) => {
+  const workspaceButton = page.getByRole("radio", {
+    name: BUTTON_NAMES.SWITCH_TO_WORKSPACE,
   });
-  await expect(workspaceButton).toBeVisible();
-  await expect(workspaceButton).toContainText("Workspace");
-  await expect(page.getByText(UI_TEXT.WORKSPACE_DESCRIPTION)).toBeVisible();
-  await expect(page.getByText(UI_TEXT.WORKSPACE_SAVED_TO)).toBeVisible();
+  await workspaceButton.click();
+};
 
-  const configScopeSection = page.locator('[data-testid="config-scope-section"]');
-  await expect(configScopeSection).toHaveClass(BORDER_CLASSES.WORKSPACE);
+const switchToLocal = async (page: Page) => {
+  const localButton = page.getByRole("radio", {
+    name: BUTTON_NAMES.SWITCH_TO_LOCAL,
+  });
+  await localButton.click();
+};
+
+const verifyWorkspaceMode = async (page: Page) => {
+  const workspaceButton = page.getByRole("radio", {
+    name: BUTTON_NAMES.SWITCH_TO_WORKSPACE,
+  });
+  await expect(workspaceButton).toHaveAttribute("aria-checked", "true");
 };
 
 const verifyGlobalMode = async (page: Page) => {
-  const globalButton = page.getByRole("button", {
-    name: BUTTON_NAMES.SWITCH_TO_WORKSPACE,
+  const globalButton = page.getByRole("radio", {
+    name: BUTTON_NAMES.SWITCH_TO_GLOBAL,
   });
-  await expect(globalButton).toBeVisible();
-  await expect(globalButton).toContainText("Global");
-  await expect(page.getByText(UI_TEXT.GLOBAL_DESCRIPTION)).toBeVisible();
-  await expect(page.getByText(UI_TEXT.GLOBAL_SAVED_TO)).toBeVisible();
+  await expect(globalButton).toHaveAttribute("aria-checked", "true");
+};
 
-  const configScopeSection = page.locator('[data-testid="config-scope-section"]');
-  await expect(configScopeSection).toHaveClass(BORDER_CLASSES.GLOBAL);
+const verifyLocalMode = async (page: Page) => {
+  const localButton = page.getByRole("radio", {
+    name: BUTTON_NAMES.SWITCH_TO_LOCAL,
+  });
+  await expect(localButton).toHaveAttribute("aria-checked", "true");
 };
 
 test.describe("Switch Workspace/Global Configuration", () => {
@@ -217,5 +208,173 @@ test.describe("Switch Workspace/Global Configuration", () => {
 
     // Then: Should directly switch to Global mode
     await verifyGlobalMode(page);
+  });
+});
+
+test.describe("Switch Local Configuration Scope", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("should switch between Workspace, Local, and Global configuration modes", async ({
+    page,
+  }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // Then: Verify initial state is Workspace mode
+    await verifyWorkspaceMode(page);
+
+    // When: Switch to Local mode
+    await switchToLocal(page);
+
+    // Then: Verify switched to Local mode
+    await verifyLocalMode(page);
+
+    // When: Switch to Global mode
+    await switchToGlobal(page);
+
+    // Then: Verify switched to Global mode
+    await verifyGlobalMode(page);
+
+    // When: Switch back to Workspace mode
+    await switchToWorkspace(page);
+
+    // Then: Verify returned to Workspace mode
+    await verifyWorkspaceMode(page);
+  });
+
+  test("should display correct icon and border for Local mode", async ({ page }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Switch to Local mode
+    await switchToLocal(page);
+
+    // Then: Verify Local mode is selected
+    await verifyLocalMode(page);
+  });
+
+  test("should persist Local scope state across interactions", async ({ page }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Switch to Local mode
+    await switchToLocal(page);
+
+    // Then: Verify Local mode is active
+    await verifyLocalMode(page);
+
+    // When: Perform other actions (e.g., open and close add dialog)
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Then: Verify Local mode is still active (state persisted)
+    await verifyLocalMode(page);
+  });
+
+  test("should show unsaved changes warning when switching from Local with edits", async ({
+    page,
+  }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Switch to Local mode
+    await switchToLocal(page);
+
+    // When: Add a new command
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByPlaceholder("e.g., $(terminal) Terminal").fill("Local Test Command");
+    await page.getByPlaceholder("e.g., npm start").fill("echo local-test");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // When: Try to switch to Workspace without saving
+    await switchToWorkspace(page);
+
+    // Then: Unsaved changes dialog should appear
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Unsaved Changes" })).toBeVisible();
+    await expect(
+      page.getByText("You have unsaved changes. What would you like to do?")
+    ).toBeVisible();
+  });
+
+  test("should save Local commands and switch to Workspace", async ({ page }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Switch to Local mode
+    await switchToLocal(page);
+
+    // When: Add a new command
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByPlaceholder("e.g., $(terminal) Terminal").fill("Local Command");
+    await page.getByPlaceholder("e.g., npm start").fill("echo local");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // When: Try to switch and save changes
+    await switchToWorkspace(page);
+    await page.getByRole("button", { name: "Save & Switch" }).click();
+
+    // Then: Should switch to Workspace mode
+    await verifyWorkspaceMode(page);
+
+    // When: Switch back to Local
+    await switchToLocal(page);
+
+    // Then: Saved command should be visible
+    await expect(page.getByText("Local Command")).toBeVisible();
+  });
+
+  test("should maintain separate configurations for Local and Workspace", async ({ page }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Add a command in Workspace
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByPlaceholder("e.g., $(terminal) Terminal").fill("Workspace Command");
+    await page.getByPlaceholder("e.g., npm start").fill("echo workspace");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // When: Switch to Local mode without saving
+    await switchToLocal(page);
+    await page.getByRole("button", { name: "Don't Save" }).click();
+
+    // Then: Local mode should not have the workspace command
+    await expect(page.getByText("Workspace Command")).not.toBeVisible();
+
+    // When: Add a different command in Local
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByPlaceholder("e.g., $(terminal) Terminal").fill("Local Command");
+    await page.getByPlaceholder("e.g., npm start").fill("echo local");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // When: Switch back to Workspace without saving
+    await switchToWorkspace(page);
+    await page.getByRole("button", { name: "Don't Save" }).click();
+
+    // Then: Workspace should not have the local command
+    await expect(page.getByText("Local Command")).not.toBeVisible();
+  });
+
+  test("should discard Local changes and switch to Global", async ({ page }) => {
+    // Given: Configuration page is loaded (from beforeEach)
+
+    // When: Switch to Local mode
+    await switchToLocal(page);
+
+    // When: Add a new command
+    await page.getByRole("button", { name: "Add new command" }).click();
+    await page.getByPlaceholder("e.g., $(terminal) Terminal").fill("Temp Local Command");
+    await page.getByPlaceholder("e.g., npm start").fill("echo temp");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // When: Try to switch and discard changes
+    await switchToGlobal(page);
+    await page.getByRole("button", { name: "Don't Save" }).click();
+
+    // Then: Should switch to Global mode
+    await verifyGlobalMode(page);
+
+    // When: Switch back to Local
+    await switchToLocal(page);
+
+    // Then: Added command should not be visible (changes discarded)
+    await expect(page.getByText("Temp Local Command")).not.toBeVisible();
   });
 });

--- a/src/view/src/components/header.tsx
+++ b/src/view/src/components/header.tsx
@@ -1,30 +1,23 @@
-import { FolderOpen, Globe, Moon, Plus, Sun } from "lucide-react";
+import { Moon, Plus, Sun } from "lucide-react";
 
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "~/core";
-import { cn } from "~/core/shadcn/utils";
 
-import { CONFIGURATION_TARGET } from "../../../shared/constants";
+import { ScopeToggleGroup } from "./scope-toggle-group";
 import { useCommandForm } from "../context/command-form-context.tsx";
 import { useVscodeCommand } from "../context/vscode-command-context.tsx";
 import { useDarkMode } from "../hooks/use-dark-mode.tsx";
 
 export const Header = () => {
-  const { configurationTarget, saveConfig, setConfigurationTarget } = useVscodeCommand();
+  const { configurationTarget, isSwitchingScope, saveConfig, setConfigurationTarget } =
+    useVscodeCommand();
   const { openForm } = useCommandForm();
   const { isDark, toggleTheme } = useDarkMode();
 
-  const isWorkspace = configurationTarget === CONFIGURATION_TARGET.WORKSPACE;
-
-  const toggleConfigurationTarget = () => {
-    const newTarget = isWorkspace ? CONFIGURATION_TARGET.GLOBAL : CONFIGURATION_TARGET.WORKSPACE;
-    setConfigurationTarget(newTarget);
-  };
-
   return (
-    <div className="flex flex-col gap-4 mb-8">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 sm:gap-0">
+    <div className="flex flex-col gap-4 mb-6">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
         <h1 className="text-2xl font-semibold text-foreground">Commands Configuration</h1>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -64,58 +57,21 @@ export const Header = () => {
           </Button>
         </div>
       </div>
-      <div
-        className={cn(
-          "flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 py-3 pl-4 pr-4",
-          "border-l-[3px]",
-          isWorkspace ? "border-l-amber-500" : "border-l-blue-500"
-        )}
-        data-testid="config-scope-section"
-      >
-        <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium text-foreground">Configuration Scope</span>
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {isWorkspace ? (
-              <FolderOpen aria-hidden="true" className="h-4 w-4 shrink-0 text-amber-500" />
-            ) : (
-              <Globe aria-hidden="true" className="h-4 w-4 shrink-0 text-blue-500" />
-            )}
-            <span>
-              {isWorkspace
-                ? "Workspace: Project-specific commands shared with team"
-                : "Global: Personal commands across all projects"}
-            </span>
-          </div>
-          <span className="text-xs text-muted-foreground/70">
-            {isWorkspace ? "Saved to .vscode/settings.json" : "Saved to user settings"}
-          </span>
-        </div>
-        <Button
-          aria-label={
-            isWorkspace
-              ? "Switch to Global settings (personal commands)"
-              : "Switch to Workspace settings (team commands)"
-          }
-          onClick={toggleConfigurationTarget}
-          title={
-            isWorkspace
-              ? "Switch to Global settings (personal commands)"
-              : "Switch to Workspace settings (team commands)"
-          }
-          variant="outline"
-        >
-          {isWorkspace ? (
-            <>
-              <FolderOpen aria-hidden="true" className="h-4 w-4 text-amber-500" />
-              Workspace
-            </>
-          ) : (
-            <>
-              <Globe aria-hidden="true" className="h-4 w-4 text-blue-500" />
-              Global
-            </>
-          )}
-        </Button>
+
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+        <span className="text-sm text-muted-foreground shrink-0">Configuration scope:</span>
+        <ScopeToggleGroup
+          disabled={isSwitchingScope}
+          onValueChange={setConfigurationTarget}
+          value={configurationTarget}
+        />
+      </div>
+
+      {/* Screen reader announcement for scope changes */}
+      <div aria-atomic="true" aria-live="polite" className="sr-only">
+        {isSwitchingScope
+          ? "Switching configuration scope..."
+          : `Configuration scope: ${configurationTarget}`}
       </div>
     </div>
   );

--- a/src/view/src/components/scope-toggle-group.tsx
+++ b/src/view/src/components/scope-toggle-group.tsx
@@ -1,0 +1,85 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/core";
+import { cn } from "~/core/shadcn/utils";
+
+import type { ConfigurationTarget } from "../../../shared/types";
+import { SCOPE_OPTIONS_WITH_COLOR } from "../constants/scope-options";
+
+type ScopeToggleGroupProps = {
+  disabled?: boolean;
+  onValueChange: (value: ConfigurationTarget) => void;
+  value: ConfigurationTarget;
+};
+
+export const ScopeToggleGroup = ({
+  disabled = false,
+  onValueChange,
+  value,
+}: ScopeToggleGroupProps) => {
+  const handleKeyDown = (e: React.KeyboardEvent, currentIndex: number) => {
+    if (disabled) return;
+
+    if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+      e.preventDefault();
+      const nextIndex =
+        e.key === "ArrowRight"
+          ? (currentIndex + 1) % SCOPE_OPTIONS_WITH_COLOR.length
+          : (currentIndex - 1 + SCOPE_OPTIONS_WITH_COLOR.length) % SCOPE_OPTIONS_WITH_COLOR.length;
+      onValueChange(SCOPE_OPTIONS_WITH_COLOR[nextIndex].value);
+    }
+  };
+
+  return (
+    <div
+      aria-label="Configuration scope"
+      className="inline-flex rounded-md border border-border bg-background shadow-sm"
+      role="radiogroup"
+    >
+      {SCOPE_OPTIONS_WITH_COLOR.map((option, index) => {
+        const Icon = option.icon;
+        const isSelected = value === option.value;
+        const isFirst = index === 0;
+        const isLast = index === SCOPE_OPTIONS_WITH_COLOR.length - 1;
+
+        return (
+          <Tooltip key={option.value}>
+            <TooltipTrigger asChild>
+              <button
+                aria-checked={isSelected}
+                aria-label={`${option.label} scope: ${option.description}. ${option.storage}`}
+                className={cn(
+                  "relative inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium transition-all cursor-pointer",
+                  "focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                  "disabled:pointer-events-none disabled:opacity-50",
+                  !isFirst && "border-l border-border",
+                  isFirst && "rounded-l-md",
+                  isLast && "rounded-r-md",
+                  isSelected
+                    ? "bg-primary text-primary-foreground shadow-sm z-[1]"
+                    : "bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                )}
+                disabled={disabled}
+                onClick={() => onValueChange(option.value)}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+                role="radio"
+                type="button"
+              >
+                <Icon
+                  aria-hidden="true"
+                  className={cn("h-3.5 w-3.5 shrink-0", !isSelected && option.iconColor)}
+                />
+                <span className="hidden sm:inline">{option.label}</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs" side="bottom">
+              <div className="flex flex-col gap-1">
+                <div className="font-semibold">{option.label}</div>
+                <div className="text-xs text-muted-foreground">{option.description}</div>
+                <div className="text-xs text-muted-foreground/70 italic">{option.storage}</div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/view/src/constants/scope-options.ts
+++ b/src/view/src/constants/scope-options.ts
@@ -1,0 +1,50 @@
+import { FolderOpen, Globe, Laptop } from "lucide-react";
+
+import { CONFIGURATION_TARGET } from "../../../shared/constants";
+import type { ConfigurationTarget } from "../../../shared/types";
+
+export const SCOPE_OPTIONS_BASE = [
+  {
+    description: "Personal commands across all projects",
+    icon: Globe,
+    label: "Global",
+    storage: "Saved to user settings",
+    value: CONFIGURATION_TARGET.GLOBAL,
+  },
+  {
+    description: "Project-specific commands shared with team",
+    icon: FolderOpen,
+    label: "Workspace",
+    storage: "Saved to .vscode/settings.json",
+    value: CONFIGURATION_TARGET.WORKSPACE,
+  },
+  {
+    description: "Personal project commands (Git-excluded)",
+    icon: Laptop,
+    label: "Local",
+    storage: "Saved to workspace state",
+    value: CONFIGURATION_TARGET.LOCAL,
+  },
+] as const;
+
+export const SCOPE_OPTIONS_WITH_COLOR = SCOPE_OPTIONS_BASE.map((option) => ({
+  ...option,
+  iconColor:
+    option.value === CONFIGURATION_TARGET.GLOBAL
+      ? "text-blue-500"
+      : option.value === CONFIGURATION_TARGET.WORKSPACE
+        ? "text-amber-500"
+        : "text-purple-500",
+}));
+
+export type ScopeOptionBase = {
+  description: string;
+  icon: typeof Globe | typeof FolderOpen | typeof Laptop;
+  label: string;
+  storage: string;
+  value: ConfigurationTarget;
+};
+
+export type ScopeOptionWithColor = ScopeOptionBase & {
+  iconColor: string;
+};


### PR DESCRIPTION
Implemented complete functionality for Local (per-project personal) configuration scope.

Key implementations:
- workspaceState-based Local storage (project isolation)
- 3-tier automatic fallback system (Local → Workspace → Global)
- Added 3-scope toggle group UI (icons + tooltips)
- Applied fallback logic to webview and tree view
- E2E tests validating scope switch scenarios

Previous commit only added type system, but this commit completes the fully functional feature.

fix #154