### PR TITLE
feat: use button name as default terminal name with [QCB] prefix

### DIFF
--- a/src/internal/managers/terminal-manager.spec.ts
+++ b/src/internal/managers/terminal-manager.spec.ts
@@ -33,28 +33,18 @@ describe("terminal-manager", () => {
 
   describe("determineTerminalName", () => {
     it("should return custom terminal name when provided", () => {
-      const result = determineTerminalName("CustomTerminal", "npm test");
+      const result = determineTerminalName("CustomTerminal", "Build");
       expect(result).toBe("CustomTerminal");
     });
 
-    it("should return first word of command when no custom name", () => {
-      const result = determineTerminalName(undefined, "npm test --verbose");
-      expect(result).toBe("npm");
+    it("should return prefixed button name when no custom name", () => {
+      const result = determineTerminalName(undefined, "Build");
+      expect(result).toBe("[QCB] Build");
     });
 
-    it("should return 'Terminal' when command is empty", () => {
-      const result = determineTerminalName(undefined, "");
-      expect(result).toBe("Terminal");
-    });
-
-    it("should return 'Terminal' when command contains only spaces", () => {
-      const result = determineTerminalName(undefined, "   ");
-      expect(result).toBe("Terminal");
-    });
-
-    it("should handle single word commands", () => {
-      const result = determineTerminalName(undefined, "ls");
-      expect(result).toBe("ls");
+    it("should handle button name with spaces", () => {
+      const result = determineTerminalName(undefined, "Run Tests");
+      expect(result).toBe("[QCB] Run Tests");
     });
   });
 
@@ -103,17 +93,17 @@ describe("terminal-manager", () => {
     });
 
     it("should create separate terminals for same command with different terminalNames", () => {
-      manager.executeCommand("just test", false, "", "just test");
-      manager.executeCommand("just test", false, undefined, "just test");
+      manager.executeCommand("just test", false, "", "Button A");
+      manager.executeCommand("just test", false, undefined, "Button A");
 
       expect(vscode.window.createTerminal).toHaveBeenCalledTimes(2);
-      expect(vscode.window.createTerminal).toHaveBeenNthCalledWith(1, "just");
-      expect(vscode.window.createTerminal).toHaveBeenNthCalledWith(2, "just");
+      expect(vscode.window.createTerminal).toHaveBeenNthCalledWith(1, "");
+      expect(vscode.window.createTerminal).toHaveBeenNthCalledWith(2, "[QCB] Button A");
     });
 
     it("should create separate terminals for executeAll group with same command", () => {
-      manager.executeCommand("just test", false, "", "just test 1");
-      manager.executeCommand("just test", false, undefined, "just test 2");
+      manager.executeCommand("just test", false, "", "Button 1");
+      manager.executeCommand("just test", false, undefined, "Button 2");
 
       expect(vscode.window.createTerminal).toHaveBeenCalledTimes(2);
     });

--- a/src/internal/managers/terminal-manager.ts
+++ b/src/internal/managers/terminal-manager.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { DEFAULT_TERMINAL_BASE_NAME, TERMINAL_NAME_PREFIX } from "../../shared/constants";
 import { TerminalExecutor } from "../adapters";
 
 export const shouldCreateNewTerminal = (terminal: vscode.Terminal | undefined): boolean => {
@@ -7,9 +8,9 @@ export const shouldCreateNewTerminal = (terminal: vscode.Terminal | undefined): 
 
 export const determineTerminalName = (
   customTerminalName: string | undefined,
-  command: string
+  baseName: string
 ): string => {
-  return customTerminalName || command.split(" ")[0] || "Terminal";
+  return customTerminalName ?? `${TERMINAL_NAME_PREFIX} ${baseName}`;
 };
 
 export class TerminalManager {
@@ -44,7 +45,8 @@ export class TerminalManager {
       return;
     }
 
-    const terminalName = determineTerminalName(customTerminalName, command);
+    const baseName = buttonName ?? command.split(" ")[0] ?? DEFAULT_TERMINAL_BASE_NAME;
+    const terminalName = determineTerminalName(customTerminalName, baseName);
     const uniqueId = this.getUniqueButtonId(buttonRef, buttonName);
     const terminalKey = JSON.stringify({
       command,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -65,6 +65,10 @@ export const COMMANDS = {
 
 export const DEFAULT_IMPORT_STRATEGY = "merge" as const;
 
+export const DEFAULT_TERMINAL_BASE_NAME = "Terminal" as const;
+
+export const TERMINAL_NAME_PREFIX = "[QCB]" as const;
+
 /**
  * VS Code ColorThemeKind enum values
  * @see https://code.visualstudio.com/api/references/vscode-api#ColorThemeKind


### PR DESCRIPTION
Previously, terminals without custom names showed only the first word of the command (npm, git, etc.), making it hard to distinguish multiple terminals

Now uses button name with [QCB] prefix for clear identification
Example: "Build" button → "[QCB] Build"