### PR TITLE
refactor: simplify user configuration by removing id field from saved data

### DIFF
--- a/src/internal/adapters.spec.ts
+++ b/src/internal/adapters.spec.ts
@@ -273,7 +273,7 @@ describe("adapters", () => {
       expect(result[1].id).toBeDefined();
     });
 
-    it("should save buttons to workspaceState", async () => {
+    it("should save buttons to workspaceState without id field", async () => {
       const buttonsToSave = [{ command: "echo test", id: "test-id", name: "Test Command" }];
 
       const mockContext = {
@@ -286,10 +286,38 @@ describe("adapters", () => {
       const localStorage = createProjectLocalStorage(mockContext);
       await localStorage.setButtons(buttonsToSave);
 
-      expect(mockContext.workspaceState.update).toHaveBeenCalledWith(
-        LOCAL_BUTTONS_STORAGE_KEY,
-        buttonsToSave
-      );
+      expect(mockContext.workspaceState.update).toHaveBeenCalledWith(LOCAL_BUTTONS_STORAGE_KEY, [
+        { command: "echo test", name: "Test Command" },
+      ]);
+    });
+
+    it("should strip ids from nested groups when saving", async () => {
+      const buttonsToSave = [
+        {
+          group: [
+            { command: "echo child", id: "child-id", name: "Child Command" },
+          ],
+          id: "parent-id",
+          name: "Parent Group",
+        },
+      ];
+
+      const mockContext = {
+        workspaceState: {
+          get: jest.fn(),
+          update: jest.fn(),
+        },
+      } as unknown as vscode.ExtensionContext;
+
+      const localStorage = createProjectLocalStorage(mockContext);
+      await localStorage.setButtons(buttonsToSave);
+
+      expect(mockContext.workspaceState.update).toHaveBeenCalledWith(LOCAL_BUTTONS_STORAGE_KEY, [
+        {
+          group: [{ command: "echo child", name: "Child Command" }],
+          name: "Parent Group",
+        },
+      ]);
     });
 
     it("should preserve existing IDs when retrieving buttons", () => {

--- a/src/internal/adapters.ts
+++ b/src/internal/adapters.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { CONFIG_SECTION } from "../pkg/config-constants";
 import { ButtonConfig, RefreshButtonConfig } from "../pkg/types";
-import { ensureIdsInArray, ButtonConfigWithOptionalId } from "./utils/ensure-id";
+import { ButtonConfigWithOptionalId, ensureIdsInArray, stripIdsInArray } from "./utils/ensure-id";
 
 const DEFAULT_REFRESH_CONFIG: RefreshButtonConfig = {
   color: "#00BCD4",
@@ -94,7 +94,8 @@ export const createVSCodeQuickPickCreator =
 export const createVSCodeConfigWriter = (): ConfigWriter => ({
   writeButtons: async (buttons: ButtonConfig[], target: vscode.ConfigurationTarget) => {
     const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
-    await config.update("buttons", buttons, target);
+    const buttonsWithoutIds = stripIdsInArray(buttons);
+    await config.update("buttons", buttonsWithoutIds, target);
   },
   writeConfigurationTarget: async (target: string) => {
     const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
@@ -112,7 +113,8 @@ export const createProjectLocalStorage = (
       return ensureIdsInArray(buttons);
     },
     setButtons: async (buttons: ButtonConfig[]) => {
-      await context.workspaceState.update(LOCAL_BUTTONS_STORAGE_KEY, buttons);
+      const buttonsWithoutIds = stripIdsInArray(buttons);
+      await context.workspaceState.update(LOCAL_BUTTONS_STORAGE_KEY, buttonsWithoutIds);
     },
   };
 };

--- a/src/internal/managers/backup-manager.spec.ts
+++ b/src/internal/managers/backup-manager.spec.ts
@@ -85,6 +85,43 @@ describe("BackupManager", () => {
       expect(content).toContain('"configurationTarget": "local"');
     });
 
+    it("should strip id fields from backup buttons", async () => {
+      mockFileSystem.exists.mockResolvedValue(true);
+
+      const result = await manager.createBackup(sampleButtons, "global");
+
+      expect(result.success).toBe(true);
+
+      const callArgs = mockFileSystem.writeFile.mock.calls[0];
+      const content = JSON.parse(callArgs[1] as string);
+
+      content.buttons.forEach((button: unknown) => {
+        expect(button).not.toHaveProperty("id");
+      });
+    });
+
+    it("should strip id fields from nested group buttons in backup", async () => {
+      mockFileSystem.exists.mockResolvedValue(true);
+
+      const buttonsWithGroups: ButtonConfig[] = [
+        {
+          group: [
+            { command: "child cmd", id: "child-1", name: "Child Command" },
+          ],
+          id: "parent-1",
+          name: "Parent Group",
+        },
+      ];
+
+      await manager.createBackup(buttonsWithGroups, "workspace");
+
+      const callArgs = mockFileSystem.writeFile.mock.calls[0];
+      const content = JSON.parse(callArgs[1] as string);
+
+      expect(content.buttons[0]).not.toHaveProperty("id");
+      expect(content.buttons[0].group[0]).not.toHaveProperty("id");
+    });
+
     it("should return error when backup creation fails", async () => {
       mockFileSystem.writeFile.mockRejectedValue(new Error("Write failed"));
 

--- a/src/internal/managers/backup-manager.ts
+++ b/src/internal/managers/backup-manager.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { ButtonConfig, ConfigurationTarget, ExportFormat } from "../../shared/types";
 import { FileSystemOperations } from "../adapters";
+import { stripIdsInArray } from "../utils/ensure-id";
 
 const EXPORT_FORMAT_VERSION = "1.0";
 const BACKUP_DIRECTORY = ".backup";
@@ -44,8 +45,9 @@ export class BackupManager {
       const backupPath = path.join(backupDirPath, filename);
       const backupUri = vscode.Uri.file(backupPath);
 
+      const buttonsWithoutIds = stripIdsInArray(buttons);
       const backupData: ExportFormat = {
-        buttons,
+        buttons: buttonsWithoutIds,
         configurationTarget: target,
         exportedAt: new Date().toISOString(),
         version: EXPORT_FORMAT_VERSION,

--- a/src/internal/utils/ensure-id.ts
+++ b/src/internal/utils/ensure-id.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "crypto";
-import { ButtonConfig } from "../../pkg/types";
+import { ButtonConfig, ButtonConfigWithOptionalId } from "../../pkg/types";
 
-export type ButtonConfigWithOptionalId = Omit<ButtonConfig, "id" | "group"> & {
-  group?: ButtonConfigWithOptionalId[];
-  id?: string;
-};
+export type { ButtonConfigWithOptionalId };
 
 export const ensureId = (config: ButtonConfigWithOptionalId): ButtonConfig => {
   const { group, id, ...restConfig } = config;
@@ -18,3 +15,19 @@ export const ensureId = (config: ButtonConfigWithOptionalId): ButtonConfig => {
 
 export const ensureIdsInArray = (configs: ButtonConfigWithOptionalId[]): ButtonConfig[] =>
   configs.map((config) => ensureId(config));
+
+export type ButtonConfigWithoutId = Omit<ButtonConfig, "id" | "group"> & {
+  group?: ButtonConfigWithoutId[];
+};
+
+export const stripId = (config: ButtonConfig): ButtonConfigWithoutId => {
+  const { group, id: _id, ...restConfig } = config;
+
+  return {
+    ...restConfig,
+    ...(group !== undefined && { group: group.map(stripId) }),
+  };
+};
+
+export const stripIdsInArray = (configs: ButtonConfig[]): ButtonConfigWithoutId[] =>
+  configs.map((config) => stripId(config));

--- a/src/pkg/types.ts
+++ b/src/pkg/types.ts
@@ -1,5 +1,6 @@
 export type {
   ButtonConfig,
+  ButtonConfigWithOptionalId,
   ConfigurationTarget,
   ExtensionMessage,
   ExtensionMessageType,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,6 +11,11 @@ export type ButtonConfig = {
   useVsCodeApi?: boolean;
 };
 
+export type ButtonConfigWithOptionalId = Omit<ButtonConfig, "id" | "group"> & {
+  group?: ButtonConfigWithOptionalId[];
+  id?: string;
+};
+
 export type RefreshButtonConfig = {
   color: string;
   enabled: boolean;
@@ -86,7 +91,7 @@ export type ExtensionMessage =
 export type ConfigurationTarget = "global" | "local" | "workspace";
 
 export type ExportFormat = {
-  buttons: ButtonConfig[];
+  buttons: ButtonConfigWithOptionalId[];
   configurationTarget: ConfigurationTarget;
   exportedAt: string;
   version: string;


### PR DESCRIPTION
- Strip id field when saving/exporting/backing up (no id in settings.json)
- Change import conflict detection from id-based to name-based
- Change import merge logic to name-based
- Maintain full backward compatibility with existing configs containing id

fix #165