### PR TITLE
fix: "Unsaved Changes" modal incorrectly shown after saving config

### DIFF
--- a/src/extension/__mocks__/vscode.js
+++ b/src/extension/__mocks__/vscode.js
@@ -27,6 +27,7 @@ module.exports = {
     onDidCloseTerminal: jest.fn(),
   },
   commands: {
+    executeCommand: jest.fn().mockResolvedValue(undefined),
     registerCommand: jest.fn(),
   },
   workspace: {

--- a/src/internal/managers/config-manager.ts
+++ b/src/internal/managers/config-manager.ts
@@ -66,11 +66,14 @@ export class ConfigManager {
     return { buttons: globalButtons, scope: CONFIGURATION_TARGETS.GLOBAL };
   }
 
-  getConfigDataForWebview(configReader: ConfigReader): {
+  getConfigDataForWebview(
+    configReader: ConfigReader,
+    overrideTarget?: ConfigurationTargetType
+  ): {
     buttons: ButtonConfig[];
     configurationTarget: ConfigurationTargetType;
   } {
-    const currentTarget = this.getCurrentConfigurationTarget();
+    const currentTarget = overrideTarget ?? this.getCurrentConfigurationTarget();
     const buttons = this.getButtonsForTarget(currentTarget, configReader);
 
     return {

--- a/src/internal/providers/webview-provider.ts
+++ b/src/internal/providers/webview-provider.ts
@@ -220,8 +220,9 @@ export const handleWebviewMessage = async (
           await configManager.updateButtonConfiguration(message.data);
           await vscode.commands.executeCommand(COMMANDS.REFRESH);
           webview.postMessage({
+            data: configManager.getConfigDataForWebview(configReader),
             requestId: message.requestId,
-            type: "success",
+            type: "configData",
           });
         } else {
           throw new Error(MESSAGES.ERROR.invalidSetConfigData);
@@ -233,9 +234,9 @@ export const handleWebviewMessage = async (
         const targetValue = message.target ?? targetData.target;
         if (isValidConfigurationTarget(targetValue)) {
           await configManager.updateConfigurationTarget(targetValue);
-          // Send configData response to both resolve the promise and update state
+          // Use targetValue directly to avoid race condition with VS Code config propagation
           webview.postMessage({
-            data: configManager.getConfigDataForWebview(configReader),
+            data: configManager.getConfigDataForWebview(configReader, targetValue),
             requestId: message.requestId,
             type: "configData",
           });

--- a/src/view/src/context/vscode-command-context.tsx
+++ b/src/view/src/context/vscode-command-context.tsx
@@ -106,10 +106,10 @@ export const VscodeCommandProvider = ({ children }: VscodeCommandProviderProps) 
     try {
       if (isDevelopment && vscodeApi.setCurrentData) {
         vscodeApi.setCurrentData(commands);
+        setInitialCommands(commands);
       } else {
         await sendMessage(MESSAGE_TYPE.SET_CONFIG, commands);
       }
-      setInitialCommands(commands);
       toast.success(MESSAGES.SUCCESS.configSaved, { duration: TOAST_DURATION.SUCCESS });
     } catch (error) {
       console.error("Failed to save config:", error);


### PR DESCRIPTION
Problem:
- "Unsaved Changes" modal appeared when switching scope after Apply Changes
- ID mismatch in React state due to ID strip/regeneration during save

Solution:
- Changed setConfig response from success to configData for proper state sync
- Removed duplicate setInitialCommands call in saveConfig
- Prevented VS Code config propagation race condition in setConfigurationTarget

fix #169