### PR TITLE
feat: detect and display shortcut conflicts during import

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,6 +128,15 @@ export type ImportConflict = {
   importedButton: ButtonConfig;
 };
 
+export type ShortcutConflict = {
+  buttons: {
+    id?: string;
+    name: string;
+    source: "existing" | "imported";
+  }[];
+  shortcut: string;
+};
+
 export type ExportResult = {
   error?: string;
   filePath?: string;
@@ -137,6 +146,7 @@ export type ExportResult = {
 export type ImportAnalysis = {
   added: ButtonConfigWithOptionalId[];
   modified: ImportConflict[];
+  shortcutConflicts: ShortcutConflict[];
   unchanged: ButtonConfigWithOptionalId[];
 };
 

--- a/src/view/src/components/import-preview-dialog.tsx
+++ b/src/view/src/components/import-preview-dialog.tsx
@@ -1,4 +1,12 @@
-import { ChevronDown, ChevronRight, FileDown, Loader2, Plus, RefreshCw } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  FileDown,
+  Loader2,
+  Plus,
+  RefreshCw,
+} from "lucide-react";
 import { useEffect, useId, useState } from "react";
 
 import {
@@ -20,6 +28,7 @@ import type {
   ImportAnalysis,
   ImportPreviewData,
   ImportStrategy,
+  ShortcutConflict,
 } from "../../../shared/types";
 
 type ImportPreviewDialogProps = {
@@ -99,7 +108,7 @@ const AnalysisSummary = ({ analysis }: { analysis: ImportAnalysis }) => {
   const total = analysis.added.length + analysis.modified.length + analysis.unchanged.length;
 
   return (
-    <div className="flex gap-4 text-sm">
+    <div className="flex flex-wrap gap-4 text-sm">
       <div className="flex items-center gap-1.5">
         <div className="w-2 h-2 rounded-full bg-green-500" />
         <span>{analysis.added.length} added</span>
@@ -112,7 +121,39 @@ const AnalysisSummary = ({ analysis }: { analysis: ImportAnalysis }) => {
         <div className="w-2 h-2 rounded-full bg-muted-foreground" />
         <span>{analysis.unchanged.length} unchanged</span>
       </div>
+      {analysis.shortcutConflicts.length > 0 && (
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-red-500" />
+          <span>{analysis.shortcutConflicts.length} shortcut conflicts</span>
+        </div>
+      )}
       <div className="ml-auto text-foreground-muted">{total} total</div>
+    </div>
+  );
+};
+
+const ShortcutConflictItem = ({ conflict }: { conflict: ShortcutConflict }) => {
+  return (
+    <div className="flex flex-col gap-1 text-sm">
+      <div className="flex items-center gap-2">
+        <code className="px-2 py-0.5 bg-red-500/20 rounded text-xs font-mono text-red-400">
+          {conflict.shortcut}
+        </code>
+        <span className="text-xs text-foreground-muted">used by:</span>
+      </div>
+      <div className="ml-4 space-y-1">
+        {conflict.buttons.map((btn, idx) => (
+          <div
+            className="flex items-center gap-2 text-xs"
+            key={btn.id ?? `${btn.source}-${btn.name}-${idx}`}
+          >
+            <span className={btn.source === "existing" ? "text-blue-400" : "text-green-400"}>
+              [{btn.source}]
+            </span>
+            <span>{btn.name}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };
@@ -177,6 +218,20 @@ export const ImportPreviewDialog = ({
                 <ButtonItem
                   button={conflict.importedButton}
                   key={`modified-${conflict.importedButton.name}-${index}`}
+                />
+              ))}
+            </CollapsibleSection>
+
+            <CollapsibleSection
+              count={analysis.shortcutConflicts.length}
+              defaultOpen={true}
+              icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
+              title="Shortcut Conflicts"
+            >
+              {analysis.shortcutConflicts.map((conflict, index) => (
+                <ShortcutConflictItem
+                  conflict={conflict}
+                  key={`shortcut-${conflict.shortcut}-${index}`}
                 />
               ))}
             </CollapsibleSection>

--- a/src/view/src/mock/vscode-mock.tsx
+++ b/src/view/src/mock/vscode-mock.tsx
@@ -6,13 +6,14 @@ import type {
   ImportPreviewResult,
   ImportResult,
   ImportStrategy,
+  ShortcutConflict,
 } from "../../../shared/types";
 import { type ButtonConfig, type VSCodeMessage } from "../types";
 import { mockCommands } from "./mock-data.tsx";
 
 const MOCK_IMPORT_BUTTONS: ButtonConfigWithOptionalId[] = [
-  { command: "npm run new-cmd", name: "New Import Command" },
-  { command: "npm run updated", name: "Build Project" },
+  { command: "npm run new-cmd", name: "New Import Command", shortcut: "t" }, // Conflicts with "$(pass) Test"
+  { command: "npm run updated", name: "Build Project", shortcut: "b" },
 ];
 
 class VSCodeMock {
@@ -169,8 +170,20 @@ class VSCodeMock {
       }
     }
 
+    // Hardcoded mock shortcut conflicts for testing UI
+    // "New Import Command" has shortcut "t" which conflicts with existing "$(pass) Test"
+    const shortcutConflicts: ShortcutConflict[] = [
+      {
+        buttons: [
+          { id: "mock-existing-1", name: "$(pass) Test", source: "existing" },
+          { id: "mock-imported-1", name: "New Import Command", source: "imported" },
+        ],
+        shortcut: "t",
+      },
+    ];
+
     return {
-      analysis: { added, modified, unchanged },
+      analysis: { added, modified, shortcutConflicts, unchanged },
       buttons: MOCK_IMPORT_BUTTONS,
       fileUri: "/mock/import/config.json",
       sourceTarget: this.configurationTarget as ConfigurationTarget,


### PR DESCRIPTION
Added shortcut conflict detection in import preview to warn users when existing and imported buttons use the same shortcuts

- Add shortcutConflicts field to ImportAnalysis type
- Implement detectShortcutConflicts logic (including nested groups)
- Add Shortcut Conflicts section to preview dialog
- Exclude same-button updates from conflict detection

fix #171