### PR TITLE
feat(i18n): add language selection dropdown to webview header

### DIFF
--- a/src/view/src/components/header.tsx
+++ b/src/view/src/components/header.tsx
@@ -1,13 +1,25 @@
-import { Moon, Plus, Sun } from "lucide-react";
+import { Check, Languages, Moon, Plus, Sun } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Button, Tooltip, TooltipContent, TooltipTrigger } from "~/core";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/core";
 
+import type { SupportedLanguage } from "../i18n";
 import { ImportExportMenu } from "./import-export-menu";
 import { ScopeToggleGroup } from "./scope-toggle-group";
 import { useCommandForm } from "../context/command-form-context.tsx";
 import { useVscodeCommand } from "../context/vscode-command-context.tsx";
 import { useDarkMode } from "../hooks/use-dark-mode.tsx";
+import { useLanguage } from "../hooks/use-language.tsx";
 
 export const Header = () => {
   const { t } = useTranslation();
@@ -15,12 +27,47 @@ export const Header = () => {
     useVscodeCommand();
   const { openForm } = useCommandForm();
   const { isDark, toggleTheme } = useDarkMode();
+  const { language, selectLanguage, supportedLanguages } = useLanguage();
+  const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
 
   return (
     <div className="flex flex-col gap-4 mb-6">
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
         <h1 className="text-2xl font-semibold text-foreground">{t("header.title")}</h1>
         <div className="flex items-center gap-2">
+          <DropdownMenu onOpenChange={setIsLanguageMenuOpen} open={isLanguageMenuOpen}>
+            <Tooltip open={isLanguageMenuOpen ? false : undefined}>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    aria-label={t("header.languageToggle")}
+                    className="btn-interactive"
+                    size="icon"
+                    variant="outline"
+                  >
+                    <Languages aria-hidden="true" className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {t("header.currentLanguage", { language: t(`header.languages.${language}`) })}
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              {supportedLanguages.map((lang) => (
+                <DropdownMenuItem
+                  key={lang}
+                  onClick={() => selectLanguage(lang as SupportedLanguage)}
+                >
+                  <Check
+                    aria-hidden="true"
+                    className={`h-4 w-4 mr-2 ${language === lang ? "opacity-100" : "opacity-0"}`}
+                  />
+                  {t(`header.languages.${lang}`)}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/view/src/hooks/use-language.tsx
+++ b/src/view/src/hooks/use-language.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from "react";
+
+import {
+  changeLanguage,
+  getCurrentLanguage,
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from "../i18n";
+
+const LANGUAGE_MANUAL_SELECTION_KEY = "language-manual-selection";
+
+const applyLanguage = (lang: SupportedLanguage, isManual: boolean): void => {
+  changeLanguage(lang);
+  if (isManual) {
+    localStorage.setItem(LANGUAGE_MANUAL_SELECTION_KEY, "true");
+  } else {
+    localStorage.removeItem(LANGUAGE_MANUAL_SELECTION_KEY);
+  }
+};
+
+const getVSCodeLanguage = (): SupportedLanguage | null => {
+  const vscodeLanguage = (window as unknown as { __VSCODE_LANGUAGE__?: string })
+    .__VSCODE_LANGUAGE__;
+  if (!vscodeLanguage) {
+    return null;
+  }
+  const baseLang = vscodeLanguage.split("-")[0];
+  return baseLang === "ko" ? "ko" : "en";
+};
+
+export const useLanguage = () => {
+  const [language, setLanguage] = useState<SupportedLanguage>(() => {
+    const isManuallySelected = localStorage.getItem(LANGUAGE_MANUAL_SELECTION_KEY) === "true";
+    if (isManuallySelected) {
+      return getCurrentLanguage();
+    }
+    return getVSCodeLanguage() || "en";
+  });
+
+  useEffect(() => {
+    const isManuallySelected = localStorage.getItem(LANGUAGE_MANUAL_SELECTION_KEY) === "true";
+    if (!isManuallySelected) {
+      const vscodeLanguage = getVSCodeLanguage();
+      if (vscodeLanguage) {
+        changeLanguage(vscodeLanguage);
+      }
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      const message = event.data;
+      if (message.type === "languageChanged" && message.data?.language) {
+        const isManuallySelected = localStorage.getItem(LANGUAGE_MANUAL_SELECTION_KEY) === "true";
+        if (!isManuallySelected) {
+          const newLanguage = message.data.language === "ko" ? "ko" : "en";
+          setLanguage(newLanguage);
+          changeLanguage(newLanguage);
+        }
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
+
+  const selectLanguage = (lang: SupportedLanguage) => {
+    setLanguage(lang);
+    applyLanguage(lang, true);
+  };
+
+  return { language, selectLanguage, supportedLanguages: SUPPORTED_LANGUAGES };
+};

--- a/src/view/src/i18n/locales/en.json
+++ b/src/view/src/i18n/locales/en.json
@@ -6,7 +6,13 @@
     "configurationScope": "Configuration scope:",
     "switchToLightMode": "Switch to light mode",
     "switchToDarkMode": "Switch to dark mode",
-    "switchingScope": "Switching configuration scope..."
+    "switchingScope": "Switching configuration scope...",
+    "languageToggle": "Change language",
+    "currentLanguage": "Current language: {{language}}",
+    "languages": {
+      "en": "English",
+      "ko": "한국어"
+    }
   },
   "emptyState": {
     "title": "No commands configured",

--- a/src/view/src/i18n/locales/ko.json
+++ b/src/view/src/i18n/locales/ko.json
@@ -6,7 +6,13 @@
     "configurationScope": "구성 스코프:",
     "switchToLightMode": "라이트 모드로 전환",
     "switchToDarkMode": "다크 모드로 전환",
-    "switchingScope": "구성 스코프 전환 중..."
+    "switchingScope": "구성 스코프 전환 중...",
+    "languageToggle": "언어 변경",
+    "currentLanguage": "현재 언어: {{language}}",
+    "languages": {
+      "en": "English",
+      "ko": "한국어"
+    }
   },
   "emptyState": {
     "title": "구성된 명령이 없습니다",


### PR DESCRIPTION
Add language selector dropdown to webview header
- useLanguage hook: localStorage-based user preference with VS Code system language fallback
- DropdownMenu for scalable language selection UI (instead of toggle button)
- Dynamic language list rendering for easy future language additions

fix #25