### PR TITLE
feat(button-set): add rename button set feature

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -27,12 +27,12 @@ export const MESSAGE_TYPE = {
   IMPORT_CONFIGURATION: "importConfiguration",
   IMPORT_PREVIEW_RESULT: "importPreviewResult",
   PREVIEW_IMPORT: "previewImport",
+  RENAME_BUTTON_SET: "renameButtonSet",
   SAVE_AS_BUTTON_SET: "saveAsButtonSet",
   SET_ACTIVE_SET: "setActiveSet",
   SET_CONFIG: "setConfig",
   SET_CONFIGURATION_TARGET: "setConfigurationTarget",
   THEME_CHANGED: "themeChanged",
-  UPDATE_BUTTON_SET: "updateButtonSet",
 } as const;
 
 export const MESSAGES = {
@@ -57,6 +57,8 @@ export const MESSAGES = {
       "Invalid import confirmation data. Please restart the import process from the preview dialog.",
     invalidSetConfigData: "Invalid data for setConfig: data is not an array.",
     noCommands: "No commands found",
+    renameButtonSetFailed: "Failed to rename button set",
+    renameRequiresBothNames: "Both current name and new name are required for rename",
     unknownError: "Unknown error occurred",
   },
   INFO: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -64,11 +64,11 @@ export type WebviewMessageType =
   | "getConfig"
   | "importConfiguration"
   | "previewImport"
+  | "renameButtonSet"
   | "saveAsButtonSet"
   | "setActiveSet"
   | "setConfig"
-  | "setConfigurationTarget"
-  | "updateButtonSet";
+  | "setConfigurationTarget";
 
 export type ExtensionMessageType =
   | "configData"
@@ -95,7 +95,7 @@ export type WebviewMessage = {
     | { setName?: string | null }
     | { strategy?: string; target?: string }
     | { buttons?: ButtonConfigWithOptionalId[]; name: string; sourceSetId?: string }
-    | { buttons: ButtonConfigWithOptionalId[]; id: string; name?: string };
+    | { currentName: string; newName: string };
   requestId?: string;
   target?: string;
   type: WebviewMessageType;

--- a/src/view/src/components/button-set-selector.tsx
+++ b/src/view/src/components/button-set-selector.tsx
@@ -1,4 +1,4 @@
-import { Check, Layers, Plus, Trash2 } from "lucide-react";
+import { Check, Layers, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -16,6 +16,8 @@ import {
 
 import { CreateSetDialog } from "./create-set-dialog";
 import { DeleteSetDialog } from "./delete-set-dialog";
+import { RenameSetDialog } from "./rename-set-dialog";
+import type { ButtonSet } from "../../../shared/types";
 import { useVscodeCommand } from "../context/vscode-command-context";
 
 export const ButtonSetSelector = () => {
@@ -24,12 +26,19 @@ export const ButtonSetSelector = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<ButtonSet | null>(null);
 
   const displayName = activeSet ?? t("buttonSets.default");
 
   const handleSetChange = async (name: string | null) => {
     await setActiveSet(name);
     setIsOpen(false);
+  };
+
+  const handleRenameClick = (e: React.MouseEvent, set: ButtonSet) => {
+    e.stopPropagation();
+    setIsOpen(false);
+    setRenameTarget(set);
   };
 
   return (
@@ -73,6 +82,15 @@ export const ButtonSetSelector = () => {
               />
               <span className="flex-1 truncate">{set.name}</span>
               <span className="ml-2 text-xs text-muted-foreground">{set.buttons.length}</span>
+              <button
+                aria-label={t("buttonSets.renameSet")}
+                className="ml-2 p-1 rounded hover:bg-accent"
+                data-testid={`rename-set-${set.id}`}
+                onClick={(e) => handleRenameClick(e, set)}
+                type="button"
+              >
+                <Pencil aria-hidden="true" className="h-3 w-3" />
+              </button>
             </DropdownMenuItem>
           ))}
 
@@ -104,6 +122,11 @@ export const ButtonSetSelector = () => {
 
       <CreateSetDialog onOpenChange={setShowCreateDialog} open={showCreateDialog} />
       <DeleteSetDialog onOpenChange={setShowDeleteDialog} open={showDeleteDialog} />
+      <RenameSetDialog
+        onOpenChange={(open) => !open && setRenameTarget(null)}
+        open={renameTarget !== null}
+        targetSet={renameTarget}
+      />
     </>
   );
 };

--- a/src/view/src/components/rename-set-dialog.tsx
+++ b/src/view/src/components/rename-set-dialog.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  FormLabel,
+  Input,
+} from "~/core";
+
+import type { ButtonSet } from "../../../shared/types";
+import { useVscodeCommand } from "../context/vscode-command-context";
+
+type RenameSetDialogProps = {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  targetSet: ButtonSet | null;
+};
+
+export const RenameSetDialog = ({ onOpenChange, open, targetSet }: RenameSetDialogProps) => {
+  const { t } = useTranslation();
+  const { buttonSets, renameButtonSet } = useVscodeCommand();
+  const [name, setName] = useState("");
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && targetSet) {
+      setName(targetSet.name);
+      setNameError(null);
+    }
+  }, [open, targetSet?.name]);
+
+  const validateName = (newName: string): boolean => {
+    if (!targetSet) {
+      return false;
+    }
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      setNameError(t("buttonSets.errors.nameRequired"));
+      return false;
+    }
+    const isDuplicate = buttonSets.some(
+      (s) =>
+        s.name.toLowerCase() === trimmed.toLowerCase() &&
+        s.name.toLowerCase() !== targetSet.name.toLowerCase()
+    );
+    if (isDuplicate) {
+      setNameError(t("buttonSets.errors.nameDuplicate"));
+      return false;
+    }
+    setNameError(null);
+    return true;
+  };
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (nameError) {
+      validateName(value);
+    }
+  };
+
+  const handleRename = async () => {
+    if (!targetSet || !validateName(name)) return;
+
+    setIsRenaming(true);
+    try {
+      const result = await renameButtonSet(targetSet.name, name.trim());
+      if (result.success) {
+        handleClose();
+      } else if (result.error) {
+        if (result.error === "duplicateSetName") {
+          setNameError(t("buttonSets.errors.nameDuplicate"));
+        } else if (result.error === "setNameRequired") {
+          setNameError(t("buttonSets.errors.nameRequired"));
+        } else if (result.error === "setNotFound") {
+          handleClose();
+        }
+      }
+    } finally {
+      setIsRenaming(false);
+    }
+  };
+
+  const handleClose = () => {
+    setName("");
+    setNameError(null);
+    onOpenChange(false);
+  };
+
+  const hasNameChanged = !!targetSet && name.trim() !== targetSet.name;
+
+  return (
+    <Dialog onOpenChange={handleClose} open={open}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("buttonSets.renameDialog.title")}</DialogTitle>
+          <DialogDescription>
+            {t("buttonSets.renameDialog.description", { name: targetSet?.name })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <div className="space-y-2">
+            <FormLabel htmlFor="rename-set-name">
+              {t("buttonSets.renameDialog.newNameLabel")}
+            </FormLabel>
+            <Input
+              className={nameError ? "border-destructive" : ""}
+              id="rename-set-name"
+              onChange={(e) => handleNameChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && hasNameChanged && !isRenaming) {
+                  handleRename();
+                }
+              }}
+              placeholder={t("buttonSets.renameDialog.newNamePlaceholder")}
+              value={name}
+            />
+            {nameError && (
+              <p aria-live="polite" className="text-sm text-destructive" role="alert">
+                {nameError}
+              </p>
+            )}
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <Button disabled={isRenaming} onClick={handleClose} variant="ghost">
+            {t("buttonSets.renameDialog.cancel")}
+          </Button>
+          <Button disabled={isRenaming || !hasNameChanged} onClick={handleRename}>
+            {isRenaming
+              ? t("buttonSets.renameDialog.renaming")
+              : t("buttonSets.renameDialog.rename")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/view/src/context/vscode-command-context.tsx
+++ b/src/view/src/context/vscode-command-context.tsx
@@ -53,6 +53,10 @@ type VscodeCommandContextType = {
   isSwitchingScope: boolean;
   removeCommandFromButton: (buttonId: string, error: ValidationError) => void;
   removeGroupFromButton: (buttonId: string, error: ValidationError) => void;
+  renameButtonSet: (
+    currentName: string,
+    newName: string
+  ) => Promise<{ error?: string; success: boolean }>;
   reorderCommands: (newCommands: ButtonConfig[]) => void;
   saveConfig: () => void;
   setActiveSet: (name: string | null) => Promise<void>;
@@ -371,6 +375,24 @@ export const VscodeCommandProvider = ({ children }: VscodeCommandProviderProps) 
     }
   };
 
+  const renameButtonSet = async (
+    currentName: string,
+    newName: string
+  ): Promise<{ error?: string; success: boolean }> => {
+    try {
+      await sendMessage(MESSAGE_TYPE.RENAME_BUTTON_SET, { currentName, newName });
+      toast.success(t("buttonSets.renamed", { name: newName }), {
+        duration: TOAST_DURATION.SUCCESS,
+      });
+      return { success: true };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      console.error("Failed to rename button set:", errorMessage, { currentName, newName });
+      toast.error(t("buttonSets.renameFailed"), { duration: TOAST_DURATION.ERROR });
+      return { error: errorMessage, success: false };
+    }
+  };
+
   return (
     <>
       <VscodeCommandContext.Provider
@@ -386,6 +408,7 @@ export const VscodeCommandProvider = ({ children }: VscodeCommandProviderProps) 
           isSwitchingScope,
           removeCommandFromButton,
           removeGroupFromButton,
+          renameButtonSet,
           reorderCommands,
           saveConfig,
           setActiveSet,

--- a/src/view/src/hooks/use-webview-communication.tsx
+++ b/src/view/src/hooks/use-webview-communication.tsx
@@ -14,7 +14,7 @@ type MessageData =
   | { preview?: unknown; strategy?: string; target?: string }
   | { setName?: string | null }
   | { buttons?: ButtonConfig[]; name: string; sourceSetId?: string }
-  | { buttons?: ButtonConfig[]; id: string; name?: string };
+  | { currentName: string; newName: string };
 
 type PendingRequest<T = void> = {
   reject: (error: Error) => void;
@@ -44,11 +44,11 @@ export const useWebviewCommunication = () => {
         | "getConfig"
         | "importConfiguration"
         | "previewImport"
+        | "renameButtonSet"
         | "saveAsButtonSet"
         | "setActiveSet"
         | "setConfig"
-        | "setConfigurationTarget"
-        | "updateButtonSet",
+        | "setConfigurationTarget",
       messageData?: MessageData,
       options?: MessageOptions
     ): Promise<T> => {

--- a/src/view/src/i18n/locales/en.json
+++ b/src/view/src/i18n/locales/en.json
@@ -216,13 +216,16 @@
     "currentSet": "Current set: {{name}}",
     "createNew": "Create new set",
     "deleteSet": "Delete set",
+    "renameSet": "Rename set",
     "switchedTo": "Switched to: {{name}}",
     "switchedToDefault": "Switched to default buttons",
     "switchFailed": "Failed to switch button set",
-    "created": "Button set \"{{name}}\" created",
     "createFailed": "Failed to create button set",
-    "deleted": "Button set \"{{name}}\" deleted",
+    "created": "Button set \"{{name}}\" created",
     "deleteFailed": "Failed to delete button set",
+    "deleted": "Button set \"{{name}}\" deleted",
+    "renameFailed": "Failed to rename button set",
+    "renamed": "Button set renamed to \"{{name}}\"",
     "errors": {
       "nameRequired": "Name is required",
       "nameDuplicate": "A set with this name already exists"
@@ -235,6 +238,15 @@
       "cancel": "Cancel",
       "create": "Create",
       "creating": "Creating..."
+    },
+    "renameDialog": {
+      "title": "Rename Button Set",
+      "description": "Enter a new name for \"{{name}}\"",
+      "newNameLabel": "New Name",
+      "newNamePlaceholder": "Enter new name",
+      "cancel": "Cancel",
+      "rename": "Rename",
+      "renaming": "Renaming..."
     },
     "deleteDialog": {
       "title": "Delete Button Set",

--- a/src/view/src/i18n/locales/ko.json
+++ b/src/view/src/i18n/locales/ko.json
@@ -216,13 +216,16 @@
     "currentSet": "현재 세트: {{name}}",
     "createNew": "새 세트 만들기",
     "deleteSet": "세트 삭제",
+    "renameSet": "세트 이름 변경",
     "switchedTo": "전환됨: {{name}}",
     "switchedToDefault": "기본 버튼으로 전환됨",
     "switchFailed": "버튼 세트 전환 실패",
-    "created": "버튼 세트 \"{{name}}\" 생성됨",
     "createFailed": "버튼 세트 생성 실패",
-    "deleted": "버튼 세트 \"{{name}}\" 삭제됨",
+    "created": "버튼 세트 \"{{name}}\" 생성됨",
     "deleteFailed": "버튼 세트 삭제 실패",
+    "deleted": "버튼 세트 \"{{name}}\" 삭제됨",
+    "renameFailed": "버튼 세트 이름 변경 실패",
+    "renamed": "버튼 세트 이름이 \"{{name}}\"(으)로 변경됨",
     "errors": {
       "nameRequired": "이름을 입력해주세요",
       "nameDuplicate": "같은 이름의 세트가 이미 존재합니다"
@@ -235,6 +238,15 @@
       "cancel": "취소",
       "create": "생성",
       "creating": "생성 중..."
+    },
+    "renameDialog": {
+      "title": "버튼 세트 이름 변경",
+      "description": "\"{{name}}\"의 새 이름을 입력하세요",
+      "newNameLabel": "새 이름",
+      "newNamePlaceholder": "새 이름 입력",
+      "cancel": "취소",
+      "rename": "변경",
+      "renaming": "변경 중..."
     },
     "deleteDialog": {
       "title": "버튼 세트 삭제",


### PR DESCRIPTION
Add button set rename functionality
- Implement RenameSetDialog component and renameButtonSet API
- Refactor generic updateButtonSet to single-purpose renameButtonSet
- Auto-sync activeSet when renaming the currently active set
- Improve accessibility (ARIA role="alert")
- Add 6 test cases including edge cases