### PR TITLE
refactor(stores): convert StatusBarManager to Store-based architecture

### DIFF
--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -324,10 +324,9 @@ export const activate = (context: vscode.ExtensionContext) => {
   const terminalManager = TerminalManager.create(eventBus);
   const configManager = ConfigManager.create({ configWriter, eventBus, localStorage });
   const statusBarManager = StatusBarManager.create({
-    configManager,
     configReader,
-    eventBus,
     statusBarCreator,
+    store: appStore,
   });
   const treeProvider = CommandTreeProvider.create({ configManager, configReader, eventBus });
   const importExportManager = ImportExportManager.create({
@@ -347,7 +346,6 @@ export const activate = (context: vscode.ExtensionContext) => {
     eventBus,
   });
 
-  statusBarManager.setButtonSetManager(buttonSetManager);
   treeProvider.setButtonSetManager(buttonSetManager);
 
   const webviewProvider = new ConfigWebviewProvider(


### PR DESCRIPTION
Remove configManager, configReader, EventBus dependencies and query state directly from Store to simplify component dependencies

- Replace EventBus multi-event subscription with single store.subscribe
- Remove ButtonSetManager dependency (activeSet queried directly from Store)
- Selector-based subscription triggers refresh only on buttons/activeSet changes
- Add error handling for subscription callback

fix #194