### PR TITLE
refactor(stores): convert CommandTreeProvider to Store-based architecture

### DIFF
--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -328,7 +328,7 @@ export const activate = (context: vscode.ExtensionContext) => {
     statusBarCreator,
     store: appStore,
   });
-  const treeProvider = CommandTreeProvider.create({ configManager, configReader, eventBus });
+  const treeProvider = CommandTreeProvider.create({ store: appStore });
   const importExportManager = ImportExportManager.create({
     configManager,
     configReader,
@@ -345,8 +345,6 @@ export const activate = (context: vscode.ExtensionContext) => {
     configReader,
     eventBus,
   });
-
-  treeProvider.setButtonSetManager(buttonSetManager);
 
   const webviewProvider = new ConfigWebviewProvider(
     context.extensionUri,


### PR DESCRIPTION
Migrate from EventBus/ConfigManager pattern to direct Zustand Store subscription
- Remove configManager, configReader, eventBus dependencies
- Remove ButtonSetManager dependency (Store manages active set buttons)
- Use store.subscribe for button change detection and auto-refresh
- Add error handling and memory leak prevention in dispose

fix #194