### PR TITLE
refactor(stores): implement Store → Settings bidirectional sync

### DIFF
--- a/src/internal/stores/store-sync.spec.ts
+++ b/src/internal/stores/store-sync.spec.ts
@@ -17,6 +17,11 @@ type MockLocalStorage = {
   setButtons: jest.Mock;
 };
 
+type MockConfigWriter = {
+  writeButtons: jest.Mock;
+  writeConfigurationTarget: jest.Mock;
+};
+
 type MockButtonSetLocalStorage = {
   getActiveSet: jest.Mock;
   getButtonSets: jest.Mock;
@@ -35,29 +40,37 @@ const createMockConfigReader = (): MockConfigReader => ({
 
 const createMockLocalStorage = (): MockLocalStorage => ({
   getButtons: jest.fn(() => []),
-  setButtons: jest.fn(),
+  setButtons: jest.fn().mockResolvedValue(undefined),
+});
+
+const createMockConfigWriter = (): MockConfigWriter => ({
+  writeButtons: jest.fn().mockResolvedValue(undefined),
+  writeConfigurationTarget: jest.fn().mockResolvedValue(undefined),
 });
 
 const createMockButtonSetLocalStorage = (): MockButtonSetLocalStorage => ({
   getActiveSet: jest.fn(() => null),
   getButtonSets: jest.fn(() => []),
-  setActiveSet: jest.fn(),
-  setButtonSets: jest.fn(),
+  setActiveSet: jest.fn().mockResolvedValue(undefined),
+  setButtonSets: jest.fn().mockResolvedValue(undefined),
 });
 
 describe("StoreSync", () => {
   let mockConfigReader: MockConfigReader;
+  let mockConfigWriter: MockConfigWriter;
   let mockLocalStorage: MockLocalStorage;
   let mockButtonSetLocalStorage: MockButtonSetLocalStorage;
   let mockWorkspaceConfig: {
     get: jest.Mock;
     inspect: jest.Mock;
+    update: jest.Mock;
   };
   let onDidChangeConfigurationCallback: ((e: vscode.ConfigurationChangeEvent) => void) | null;
 
   beforeEach(() => {
     resetAppStore();
     mockConfigReader = createMockConfigReader();
+    mockConfigWriter = createMockConfigWriter();
     mockLocalStorage = createMockLocalStorage();
     mockButtonSetLocalStorage = createMockButtonSetLocalStorage();
     onDidChangeConfigurationCallback = null;
@@ -71,6 +84,7 @@ describe("StoreSync", () => {
         globalValue: undefined,
         workspaceValue: undefined,
       })),
+      update: jest.fn().mockResolvedValue(undefined),
     };
 
     (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue(mockWorkspaceConfig);
@@ -429,6 +443,423 @@ describe("StoreSync", () => {
       storeSync.initializeFromSettings();
 
       expect(store.getState().buttons).toEqual(workspaceButtons);
+    });
+  });
+
+  describe("Store → Settings sync (bidirectional)", () => {
+    describe("buttons sync", () => {
+      it("should save buttons to workspace settings when store changes", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const newButtons: ButtonConfig[] = [{ command: "echo new", id: "new", name: "New" }];
+        store.getState().setButtons(newButtons);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockConfigWriter.writeButtons).toHaveBeenCalledWith(
+          newButtons,
+          vscode.ConfigurationTarget.Workspace
+        );
+      });
+
+      it("should save buttons to global settings when configTarget is global", async () => {
+        const store = createAppStore();
+        mockWorkspaceConfig.get.mockImplementation((key: string, defaultValue?: unknown) => {
+          if (key === "configurationTarget") return "global";
+          return defaultValue;
+        });
+
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const newButtons: ButtonConfig[] = [{ command: "echo global", id: "g", name: "Global" }];
+        store.getState().setButtons(newButtons);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockConfigWriter.writeButtons).toHaveBeenCalledWith(
+          newButtons,
+          vscode.ConfigurationTarget.Global
+        );
+      });
+
+      it("should save buttons to local storage when configTarget is local", async () => {
+        const store = createAppStore();
+        mockWorkspaceConfig.get.mockImplementation((key: string, defaultValue?: unknown) => {
+          if (key === "configurationTarget") return "local";
+          return defaultValue;
+        });
+        mockLocalStorage.getButtons.mockReturnValue([{ command: "test", id: "1", name: "Test" }]);
+
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          localStorage: mockLocalStorage,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const newButtons: ButtonConfig[] = [{ command: "echo local", id: "l", name: "Local" }];
+        store.getState().setButtons(newButtons);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockLocalStorage.setButtons).toHaveBeenCalledWith(newButtons);
+        expect(mockConfigWriter.writeButtons).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("buttonSets sync", () => {
+      it("should save buttonSets to workspace settings when store changes", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const newSets: ButtonSet[] = [{ buttons: [], id: "set-1", name: "DevSet" }];
+        store.getState().setButtonSets(newSets);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockWorkspaceConfig.update).toHaveBeenCalledWith(
+          "buttonSets",
+          [{ buttons: [], name: "DevSet" }],
+          vscode.ConfigurationTarget.Workspace
+        );
+      });
+
+      it("should save buttonSets to local storage when configTarget is local", async () => {
+        const store = createAppStore();
+        mockWorkspaceConfig.get.mockImplementation((key: string, defaultValue?: unknown) => {
+          if (key === "configurationTarget") return "local";
+          return defaultValue;
+        });
+        mockLocalStorage.getButtons.mockReturnValue([{ command: "test", id: "1", name: "Test" }]);
+
+        const storeSync = StoreSync.create({
+          buttonSetLocalStorage: mockButtonSetLocalStorage,
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          localStorage: mockLocalStorage,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const newSets: ButtonSet[] = [{ buttons: [], id: "local-set", name: "LocalSet" }];
+        store.getState().setButtonSets(newSets);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockButtonSetLocalStorage.setButtonSets).toHaveBeenCalledWith(newSets);
+      });
+    });
+
+    describe("activeSet sync", () => {
+      it("should save activeSet to workspace settings when store changes", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        store.getState().setActiveSet("DevSet");
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockWorkspaceConfig.update).toHaveBeenCalledWith(
+          "activeSet",
+          "DevSet",
+          vscode.ConfigurationTarget.Workspace
+        );
+      });
+
+      it("should save null activeSet to settings when clearing", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        store.getState().setActiveSet("TempSet");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        mockWorkspaceConfig.update.mockClear();
+
+        store.getState().setActiveSet(null);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockWorkspaceConfig.update).toHaveBeenCalledWith(
+          "activeSet",
+          null,
+          vscode.ConfigurationTarget.Workspace
+        );
+      });
+
+      it("should save activeSet to local storage when configTarget is local", async () => {
+        const store = createAppStore();
+        mockWorkspaceConfig.get.mockImplementation((key: string, defaultValue?: unknown) => {
+          if (key === "configurationTarget") return "local";
+          return defaultValue;
+        });
+        mockLocalStorage.getButtons.mockReturnValue([{ command: "test", id: "1", name: "Test" }]);
+
+        const storeSync = StoreSync.create({
+          buttonSetLocalStorage: mockButtonSetLocalStorage,
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          localStorage: mockLocalStorage,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        store.getState().setActiveSet("LocalSet");
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockButtonSetLocalStorage.setActiveSet).toHaveBeenCalledWith("LocalSet");
+      });
+    });
+
+    describe("circular update prevention", () => {
+      it("should not save to settings when syncing from settings", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        mockConfigWriter.writeButtons.mockClear();
+
+        const newButtons: ButtonConfig[] = [{ command: "echo new", id: "new", name: "New" }];
+        mockConfigReader.getButtonsFromScope.mockReturnValue(newButtons);
+
+        onDidChangeConfigurationCallback?.({
+          affectsConfiguration: (section: string) => section === "quickCommandButtons",
+        } as vscode.ConfigurationChangeEvent);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockConfigWriter.writeButtons).not.toHaveBeenCalled();
+      });
+
+      it("should not trigger settings change handler when saving to settings", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const newButtons: ButtonConfig[] = [{ command: "echo new", id: "new", name: "New" }];
+        store.getState().setButtons(newButtons);
+
+        mockConfigWriter.writeButtons.mockImplementation(async () => {
+          onDidChangeConfigurationCallback?.({
+            affectsConfiguration: (section: string) => section === "quickCommandButtons",
+          } as vscode.ConfigurationChangeEvent);
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(store.getState().buttons).toEqual(newButtons);
+      });
+    });
+
+    describe("dispose", () => {
+      it("should unsubscribe store listeners on dispose", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+        storeSync.dispose();
+
+        mockConfigWriter.writeButtons.mockClear();
+        store.getState().setButtons([{ command: "test", id: "1", name: "Test" }]);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(mockConfigWriter.writeButtons).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("error handling", () => {
+      it("should show error message when save fails", async () => {
+        const store = createAppStore();
+        mockConfigWriter.writeButtons.mockRejectedValue(new Error("Permission denied"));
+
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+        store.getState().setButtons([{ command: "test", id: "1", name: "Test" }]);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[StoreSync] Failed to save buttons:",
+          expect.any(Error)
+        );
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          "Failed to save buttons: Permission denied"
+        );
+
+        consoleSpy.mockRestore();
+      });
+
+      it("should throw error when configWriter is missing for non-local scope", async () => {
+        const store = createAppStore();
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+        store.getState().setButtons([{ command: "test", id: "1", name: "Test" }]);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[StoreSync] Failed to save buttons:",
+          expect.objectContaining({
+            message: "ConfigWriter is required for workspace/global scope",
+          })
+        );
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          "Failed to save buttons: ConfigWriter is required for workspace/global scope"
+        );
+
+        consoleSpy.mockRestore();
+      });
+
+      it("should handle rapid consecutive updates without losing data", async () => {
+        const store = createAppStore();
+        let saveCount = 0;
+        mockConfigWriter.writeButtons.mockImplementation(async () => {
+          saveCount++;
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        });
+
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const buttons1: ButtonConfig[] = [{ command: "echo 1", id: "1", name: "First" }];
+        const buttons2: ButtonConfig[] = [{ command: "echo 2", id: "2", name: "Second" }];
+        const buttons3: ButtonConfig[] = [{ command: "echo 3", id: "3", name: "Third" }];
+
+        store.getState().setButtons(buttons1);
+        store.getState().setButtons(buttons2);
+        store.getState().setButtons(buttons3);
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(saveCount).toBe(3);
+        expect(mockConfigWriter.writeButtons).toHaveBeenLastCalledWith(
+          buttons3,
+          vscode.ConfigurationTarget.Workspace
+        );
+      });
+
+      it("should handle buttonSets save error gracefully", async () => {
+        const store = createAppStore();
+        mockWorkspaceConfig.update.mockRejectedValue(new Error("Write failed"));
+
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+        store.getState().setButtonSets([{ buttons: [], id: "set-1", name: "TestSet" }]);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[StoreSync] Failed to save buttonSets:",
+          expect.any(Error)
+        );
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          "Failed to save buttonSets: Write failed"
+        );
+
+        consoleSpy.mockRestore();
+      });
+
+      it("should handle activeSet save error gracefully", async () => {
+        const store = createAppStore();
+        mockWorkspaceConfig.update.mockRejectedValue(new Error("Update failed"));
+
+        const storeSync = StoreSync.create({
+          configReader: mockConfigReader,
+          configWriter: mockConfigWriter,
+          store,
+        });
+        storeSync.initializeFromSettings();
+        storeSync.startBidirectionalSync();
+
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+        store.getState().setActiveSet("TestSet");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "[StoreSync] Failed to save activeSet:",
+          expect.any(Error)
+        );
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          "Failed to save activeSet: Update failed"
+        );
+
+        consoleSpy.mockRestore();
+      });
     });
   });
 });

--- a/src/internal/stores/store-sync.ts
+++ b/src/internal/stores/store-sync.ts
@@ -1,23 +1,28 @@
 import * as vscode from "vscode";
 import {
+  CONFIG_KEYS,
   CONFIG_SECTION,
   CONFIGURATION_TARGETS,
   ConfigurationTargetType,
+  VS_CODE_CONFIGURATION_TARGETS,
 } from "../../pkg/config-constants";
-import { ButtonSet } from "../../shared/types";
-import { ConfigReader, ProjectLocalStorage } from "../adapters";
+import { ButtonConfig, ButtonSet } from "../../shared/types";
+import { ConfigReader, ConfigWriter, ProjectLocalStorage } from "../adapters";
 import { resolveButtonsWithFallback } from "../utils/config-fallback";
-import { ensureSetIdsInArray } from "../utils/ensure-id";
+import { ensureSetIdsInArray, stripSetIdsInArray } from "../utils/ensure-id";
 import type { AppStoreInstance } from "./app-store";
 
 type ButtonSetLocalStorage = {
   getActiveSet: () => string | null;
   getButtonSets: () => ButtonSet[];
+  setActiveSet: (name: string | null) => Promise<void>;
+  setButtonSets: (sets: ButtonSet[]) => Promise<void>;
 };
 
 type StoreSyncDeps = {
   buttonSetLocalStorage?: ButtonSetLocalStorage;
   configReader: ConfigReader;
+  configWriter?: ConfigWriter;
   localStorage?: ProjectLocalStorage;
   store: AppStoreInstance;
 };
@@ -26,14 +31,18 @@ export class StoreSync implements vscode.Disposable {
   private readonly buttonSetLocalStorage?: ButtonSetLocalStorage;
   private configChangeListener?: vscode.Disposable;
   private readonly configReader: ConfigReader;
+  private readonly configWriter?: ConfigWriter;
   private isSyncingFromSettings = false;
   private isSyncingToSettings = false;
   private readonly localStorage?: ProjectLocalStorage;
+  private pendingSaves = new Map<string, Promise<void>>();
   private readonly store: AppStoreInstance;
+  private storeUnsubscribes: (() => void)[] = [];
 
   private constructor(deps: StoreSyncDeps) {
     this.buttonSetLocalStorage = deps.buttonSetLocalStorage;
     this.configReader = deps.configReader;
+    this.configWriter = deps.configWriter;
     this.localStorage = deps.localStorage;
     this.store = deps.store;
   }
@@ -44,10 +53,17 @@ export class StoreSync implements vscode.Disposable {
 
   dispose(): void {
     this.configChangeListener?.dispose();
+    this.storeUnsubscribes.forEach((unsubscribe) => unsubscribe());
+    this.storeUnsubscribes = [];
   }
 
   initializeFromSettings(): void {
     this.syncFromSettings();
+  }
+
+  startBidirectionalSync(): void {
+    this.startSettingsChangeListener();
+    this.startStoreChangeListener();
   }
 
   startSettingsChangeListener(): void {
@@ -57,6 +73,25 @@ export class StoreSync implements vscode.Disposable {
       }
       this.onSettingsChange();
     });
+  }
+
+  startStoreChangeListener(): void {
+    const unsubscribeButtons = this.store.subscribe(
+      (state) => state.buttons,
+      (buttons) => this.onStoreButtonsChange(buttons)
+    );
+
+    const unsubscribeButtonSets = this.store.subscribe(
+      (state) => state.buttonSets,
+      (buttonSets) => this.onStoreButtonSetsChange(buttonSets)
+    );
+
+    const unsubscribeActiveSet = this.store.subscribe(
+      (state) => state.activeSet,
+      (activeSet) => this.onStoreActiveSetChange(activeSet)
+    );
+
+    this.storeUnsubscribes.push(unsubscribeButtons, unsubscribeButtonSets, unsubscribeActiveSet);
   }
 
   private getActiveSetForTarget(target: ConfigurationTargetType): string | null {
@@ -111,6 +146,104 @@ export class StoreSync implements vscode.Disposable {
     } finally {
       this.isSyncingFromSettings = false;
     }
+  }
+
+  private onStoreActiveSetChange(activeSet: string | null): void {
+    if (this.isSyncingFromSettings) {
+      return;
+    }
+    this.queueSave(CONFIG_KEYS.ACTIVE_SET, () => this.saveActiveSetToSettings(activeSet));
+  }
+
+  private onStoreButtonsChange(buttons: ButtonConfig[]): void {
+    if (this.isSyncingFromSettings) {
+      return;
+    }
+    this.queueSave(CONFIG_KEYS.BUTTONS, () => this.saveButtonsToSettings(buttons));
+  }
+
+  private onStoreButtonSetsChange(buttonSets: ButtonSet[]): void {
+    if (this.isSyncingFromSettings) {
+      return;
+    }
+    this.queueSave(CONFIG_KEYS.BUTTON_SETS, () => this.saveButtonSetsToSettings(buttonSets));
+  }
+
+  private queueSave(key: string, saveFn: () => Promise<void>): void {
+    const previousSave = this.pendingSaves.get(key) ?? Promise.resolve();
+
+    const currentSave = previousSave
+      .then(() => {
+        this.isSyncingToSettings = true;
+        return saveFn();
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        console.error(`[StoreSync] Failed to save ${key}:`, error);
+        vscode.window.showErrorMessage(`Failed to save ${key}: ${message}`);
+      })
+      .finally(() => {
+        if (this.pendingSaves.get(key) === currentSave) {
+          this.pendingSaves.delete(key);
+        }
+        if (this.pendingSaves.size === 0) {
+          this.isSyncingToSettings = false;
+        }
+      });
+
+    this.pendingSaves.set(key, currentSave);
+  }
+
+  private async saveActiveSetToSettings(activeSet: string | null): Promise<void> {
+    const configTarget = this.store.getState().configTarget;
+
+    if (configTarget === CONFIGURATION_TARGETS.LOCAL) {
+      if (!this.buttonSetLocalStorage) {
+        throw new Error("ButtonSetLocalStorage is required for local scope");
+      }
+      await this.buttonSetLocalStorage.setActiveSet(activeSet);
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    const vsCodeTarget = VS_CODE_CONFIGURATION_TARGETS[configTarget];
+    await config.update(CONFIG_KEYS.ACTIVE_SET, activeSet, vsCodeTarget);
+  }
+
+  private async saveButtonSetsToSettings(buttonSets: ButtonSet[]): Promise<void> {
+    const configTarget = this.store.getState().configTarget;
+
+    if (configTarget === CONFIGURATION_TARGETS.LOCAL) {
+      if (!this.buttonSetLocalStorage) {
+        throw new Error("ButtonSetLocalStorage is required for local scope");
+      }
+      await this.buttonSetLocalStorage.setButtonSets(buttonSets);
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+    const vsCodeTarget = VS_CODE_CONFIGURATION_TARGETS[configTarget];
+    const setsWithoutIds = stripSetIdsInArray(buttonSets);
+    await config.update(CONFIG_KEYS.BUTTON_SETS, setsWithoutIds, vsCodeTarget);
+  }
+
+  private async saveButtonsToSettings(buttons: ButtonConfig[]): Promise<void> {
+    const configTarget = this.store.getState().configTarget;
+
+    if (configTarget === CONFIGURATION_TARGETS.LOCAL) {
+      if (!this.localStorage) {
+        throw new Error("ProjectLocalStorage is required for local scope");
+      }
+      await this.localStorage.setButtons(buttons);
+      return;
+    }
+
+    if (!this.configWriter) {
+      throw new Error("ConfigWriter is required for workspace/global scope");
+    }
+
+    const vsCodeTarget = VS_CODE_CONFIGURATION_TARGETS[configTarget];
+    await this.configWriter.writeButtons(buttons, vsCodeTarget);
   }
 
   private syncFromSettings(): void {


### PR DESCRIPTION
Settings were lost because Store changes were not auto-saved to VS Code Settings

- Add queueSave pattern to prevent race conditions on consecutive updates
- Show vscode.window.showErrorMessage on save failures
- Throw explicit error when configWriter is missing to prevent silent failures
- Branch save logic by LOCAL/WORKSPACE/GLOBAL scope

fix #194