### PR TITLE
ci: implement Jest test 4-shard parallel execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
 
     steps:
       - name: Checkout
@@ -50,8 +55,56 @@ jobs:
       - name: Install dependencies
         run: just deps-compact
 
-      - name: Run tests with coverage
-        run: just test extension coverage
+      - name: Run tests with coverage (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: just test extension coverage "${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-${{ matrix.shardIndex }}
+          path: src/extension/coverage/
+          retention-days: 1
+
+  coverage-merge:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.18.0"
+
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts/
+
+      - name: Merge coverage reports
+        run: |
+          npm install -g nyc
+          mkdir -p merged-coverage
+          # Copy all coverage-final.json files with unique names
+          for dir in coverage-artifacts/coverage-*; do
+            shard=$(basename "$dir" | sed 's/coverage-//')
+            if [ -f "$dir/coverage-final.json" ]; then
+              cp "$dir/coverage-final.json" "merged-coverage/coverage-$shard.json"
+            fi
+          done
+          # Merge and generate report
+          nyc merge merged-coverage merged-coverage/coverage.json
+          nyc report --reporter=lcov --reporter=text --temp-dir=merged-coverage --report-dir=coverage-report
+
+      - name: Upload merged coverage report
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-report
+          path: coverage-report/
+          retention-days: 30
 
   e2e-ui-test:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -118,22 +118,30 @@ release:
 run-view:
     cd "{{ view_dir }}" && pnpm dev
 
-test target="" mode="":
+test target="" mode="" shard="":
     #!/usr/bin/env bash
     set -euo pipefail
     case "{{ target }}" in
       "")
-        just test extension "{{ mode }}"
-        just test e2e-ui "{{ mode }}"
+        just test extension "{{ mode }}" "{{ shard }}"
+        just test e2e-ui "{{ mode }}" "{{ shard }}"
         ;;
       extension)
-        cd "{{ root_dir }}"
+        cd "{{ extension_dir }}"
         if [ "{{ mode }}" = "watch" ]; then
-          pnpm test:watch
+          pnpm test -- --watch
         elif [ "{{ mode }}" = "coverage" ]; then
-          pnpm test:coverage
+          if [ -n "{{ shard }}" ]; then
+            pnpm test -- --coverage --shard="{{ shard }}"
+          else
+            pnpm test -- --coverage
+          fi
         else
-          pnpm test
+          if [ -n "{{ shard }}" ]; then
+            pnpm test -- --shard="{{ shard }}"
+          else
+            pnpm test
+          fi
         fi
         ;;
       e2e-ui)
@@ -150,7 +158,7 @@ test target="" mode="":
         ;;
       *)
         echo "Unknown target: {{ target }}"
-        echo "Usage: just test [extension|e2e-ui] [mode]"
+        echo "Usage: just test [extension|e2e-ui] [mode] [shard]"
         exit 1
         ;;
     esac

--- a/src/extension/jest.config.cjs
+++ b/src/extension/jest.config.cjs
@@ -10,7 +10,7 @@ module.exports = {
     "!**/__mocks__/**",
   ],
   coverageDirectory: "<rootDir>/extension/coverage",
-  coverageReporters: ["text", "lcov", "html"],
+  coverageReporters: ["text", "lcov", "html", "json"],
   moduleDirectories: [
     "node_modules",
     "<rootDir>/extension/node_modules",


### PR DESCRIPTION
Distribute Jest tests across 4 shards to reduce CI execution time

- Add GitHub Actions matrix strategy for 4 parallel jobs
- Add shard parameter support to justfile
- Upload per-shard coverage artifacts and merge with nyc
- Add JSON reporter to Jest config for coverage merging

fix #200